### PR TITLE
fix: ensure assets load on custom domain

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
+import fs from 'node:fs';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 const repository = process.env.GITHUB_REPOSITORY;
 const repoName = repository?.split('/')[1]?.trim();
-
-const base = repoName ? `/${repoName}/` : '/tn-roadmap/';
+const hasCustomDomain = fs.existsSync(new URL('./CNAME', import.meta.url));
+const base = hasCustomDomain ? '/' : repoName ? `/${repoName}/` : '/';
 
 export default defineConfig(({ command }) => ({
   base: command === 'serve' ? '/' : base,


### PR DESCRIPTION
## Summary
- detect the presence of the CNAME file to infer custom domain usage
- force Vite to output root-relative asset URLs when building for production in that case

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d57bb0272883309d5827f222197d73