### PR TITLE
feat: align roadmap layout with design

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { motion, useReducedMotion } from 'framer-motion';
+import { useEffect, useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
 import { LearnMore } from './components/LearnMore';
 import { PhaseOverview } from './components/PhaseOverview';
 import { ProgressBar } from './components/ProgressBar';
-import { RoadToDeploymentFlow } from './components/RoadToDeployment/Flow';
 import { RoadToMainnet } from './components/RoadToMainnet';
 import { SecurityAudits } from './components/SecurityAudits';
-import { GradientCanvas } from './components/GradientCanvas';
 import { loadStatus, type Status } from './data/loadStatus';
-import type { Phase as RoadmapPhase } from './data/roadmap';
 import { formatList } from './utils/formatList';
 import { NetworkIcon } from './components/icons';
 
@@ -44,8 +41,6 @@ function HeaderSkeleton() {
 
 export default function App() {
   const [status, setStatus] = useState<Status | null>(null);
-  const reduceMotion = useReducedMotion();
-
   useEffect(() => {
     const data = loadStatus();
     const timeout = window.setTimeout(() => {
@@ -76,30 +71,10 @@ export default function App() {
     ? `Visibility into our ${readablePhaseList} progress and what remains before launch.`
     : 'Visibility into Telcoin Network progress and what remains before launch.';
 
-  const handleFlowSelect = useCallback(
-    (phase: RoadmapPhase) => {
-      const target = phase.links?.[0]?.href;
-      if (!target) return;
-      const elementId = target.startsWith('#') ? target.slice(1) : target;
-      const element = document.getElementById(elementId);
-      if (!element) return;
-      element.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
-      const accordionTrigger = element.querySelector('button');
-      if (accordionTrigger instanceof HTMLButtonElement) {
-        window.setTimeout(() => {
-          accordionTrigger.focus({ preventScroll: true });
-          accordionTrigger.click();
-        }, reduceMotion ? 0 : 160);
-      }
-    },
-    [reduceMotion]
-  );
-
   return (
-    <div className="relative min-h-screen overflow-x-hidden bg-bg text-fg">
-      <GradientCanvas />
-      <header className="relative isolate border-b border-border/60 bg-bg/70 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl flex-col gap-8 px-6 py-12 text-center md:px-8">
+    <div className="min-h-screen bg-bg text-fg">
+      <header className="border-b border-border/70 bg-white/80 backdrop-blur">
+        <div className="mx-auto max-w-5xl px-6 py-16 md:px-8">
           {showSkeleton ? (
             <HeaderSkeleton />
           ) : (
@@ -107,33 +82,33 @@ export default function App() {
               initial="hidden"
               animate="visible"
               variants={sectionVariants}
-              transition={{ duration: 0.6, ease: 'easeOut' }}
-              className="space-y-6"
+              transition={{ duration: 0.5, ease: 'easeOut' }}
+              className="space-y-8"
             >
-              <div className="flex items-center justify-center gap-3">
-                <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/15 text-primary">
-                  <NetworkIcon className="h-5 w-5" />
-                </span>
-                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-fg-muted/80">
-                  Telcoin Network
-                </p>
-              </div>
-              <h1 className="text-3xl font-bold text-fg md:text-4xl">Telcoin Network Status</h1>
-              <p className="mx-auto max-w-2xl text-base text-fg-muted">{headerDescription}</p>
-              <div className="relative mx-auto max-w-xl overflow-hidden rounded-3xl border border-border/60 bg-card/80 p-6 text-left shadow-glow">
-                <div className="pointer-events-none absolute inset-y-0 -left-1 w-1/2 bg-[radial-gradient(circle_at_top,var(--primary)/0.15,transparent_60%)]" />
-                <div className="pointer-events-none absolute inset-y-0 -right-1 w-1/2 bg-[radial-gradient(circle_at_bottom,var(--accent)/0.12,transparent_60%)]" />
-                <ProgressBar value={status.meta.overallTrajectoryPct} label="Overall trajectory" />
-                <p className="mt-4 text-sm text-fg-muted">
-                  Last updated <time dateTime={status.meta.lastUpdated}>{formattedLastUpdated}</time>
-                </p>
+              <div className="flex flex-col items-center gap-6 text-center md:flex-row md:items-center md:justify-between md:text-left">
+                <div className="space-y-4">
+                  <span className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-primary">
+                    <NetworkIcon className="h-4 w-4" />
+                    Telcoin Network
+                  </span>
+                  <div className="space-y-3">
+                    <h1 className="text-3xl font-semibold text-fg md:text-4xl">Telcoin Network Status</h1>
+                    <p className="max-w-xl text-base text-fg-muted md:text-lg">{headerDescription}</p>
+                  </div>
+                </div>
+                <div className="w-full max-w-sm rounded-3xl border border-border/80 bg-white p-6 shadow-soft">
+                  <ProgressBar value={status.meta.overallTrajectoryPct} label="Overall trajectory" />
+                  <p className="mt-4 text-sm text-fg-muted">
+                    Last updated <time dateTime={status.meta.lastUpdated}>{formattedLastUpdated}</time>
+                  </p>
+                </div>
               </div>
             </motion.div>
           )}
         </div>
       </header>
       <main
-        className="relative mx-auto mt-12 flex max-w-6xl flex-col gap-16 px-6 pb-16 md:px-8"
+        className="mx-auto max-w-5xl space-y-16 px-6 py-16 md:px-8"
         aria-busy={showSkeleton}
         aria-live="polite"
       >
@@ -145,7 +120,6 @@ export default function App() {
               ))}
             </div>
             <SkeletonSection className="h-64" />
-            <SkeletonSection className="h-80" />
             <SkeletonSection className="h-72" />
           </>
         ) : (
@@ -155,7 +129,7 @@ export default function App() {
               initial="hidden"
               whileInView="visible"
               viewport={{ once: true, amount: 0.3 }}
-              transition={{ duration: 0.6, ease: 'easeOut' }}
+              transition={{ duration: 0.5, ease: 'easeOut' }}
             >
               <PhaseOverview phases={status.phases} />
             </motion.section>
@@ -166,7 +140,7 @@ export default function App() {
               initial="hidden"
               whileInView="visible"
               viewport={{ once: true, amount: 0.3 }}
-              transition={{ duration: 0.6, ease: 'easeOut', delay: 0.05 }}
+              transition={{ duration: 0.5, ease: 'easeOut', delay: 0.05 }}
             >
               <SecurityAudits
                 notes={status.security.notes}
@@ -180,17 +154,7 @@ export default function App() {
               initial="hidden"
               whileInView="visible"
               viewport={{ once: true, amount: 0.3 }}
-              transition={{ duration: 0.6, ease: 'easeOut', delay: 0.05 }}
-            >
-              <RoadToDeploymentFlow onSelectPhase={handleFlowSelect} />
-            </motion.section>
-
-            <motion.section
-              variants={sectionVariants}
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true, amount: 0.3 }}
-              transition={{ duration: 0.6, ease: 'easeOut', delay: 0.05 }}
+              transition={{ duration: 0.5, ease: 'easeOut', delay: 0.05 }}
             >
               <RoadToMainnet steps={status.roadmap} />
             </motion.section>
@@ -200,14 +164,14 @@ export default function App() {
               initial="hidden"
               whileInView="visible"
               viewport={{ once: true, amount: 0.2 }}
-              transition={{ duration: 0.6, ease: 'easeOut', delay: 0.05 }}
+              transition={{ duration: 0.5, ease: 'easeOut', delay: 0.05 }}
             >
               <LearnMore phases={status.phases} links={status.links} />
             </motion.section>
           </>
         )}
       </main>
-      <footer className="border-t border-border/60 bg-bg/80 py-8 text-center text-sm text-fg-muted">
+      <footer className="border-t border-border/70 bg-white/90 py-8 text-center text-sm text-fg-muted">
         © {new Date().getFullYear()} Telcoin Network — roadmap snapshot for engineering stakeholders.
       </footer>
     </div>

--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -38,7 +38,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
   return (
     <section aria-labelledby="learn-more-heading" className="space-y-6">
       <div className="flex items-start gap-3">
-        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
           <InfoIcon className="h-6 w-6" />
         </div>
         <div className="space-y-1">
@@ -57,7 +57,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
             <article
               key={question.id}
               id={`learn-more-${question.id}`}
-              className="overflow-hidden rounded-2xl border border-border bg-card/95 shadow-glow"
+              className="overflow-hidden rounded-2xl border border-border/80 bg-white shadow-soft"
             >
               <motion.button
                 type="button"
@@ -68,7 +68,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
                 whileTap={{ scale: 0.99 }}
               >
                 <span className="flex items-center gap-3 text-base font-semibold text-fg">
-                  <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/12 text-primary">
+                  <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
                     <InfoIcon className="h-5 w-5" />
                   </span>
                   {question.title}
@@ -94,7 +94,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
         {linkButtons.map((link) => (
           <motion.a
             key={link.label}
-            className="inline-flex items-center gap-2 rounded-full border border-border bg-card/90 px-4 py-2 text-sm font-medium text-fg shadow-glow transition hover:-translate-y-0.5 hover:text-primary"
+            className="inline-flex items-center gap-2 rounded-full border border-border/80 bg-white px-4 py-2 text-sm font-medium text-fg shadow-soft transition hover:-translate-y-0.5 hover:text-primary"
             href={link.href}
             target="_blank"
             rel="noreferrer noopener"

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -6,17 +6,17 @@ import { formatList } from '../utils/formatList';
 const STATUS_LABELS: Record<Phase['status'], { text: string; className: string; ariaLabel: string }> = {
   in_progress: {
     text: 'In progress',
-    className: 'bg-primary/10 text-primary border border-primary/40',
+    className: 'border-primary/40 bg-primary/10 text-primary',
     ariaLabel: 'Phase is in progress'
   },
   upcoming: {
     text: 'Upcoming',
-    className: 'bg-bg-elev text-fg-muted border border-border/70',
+    className: 'border-border/60 bg-bg-elev text-fg-muted',
     ariaLabel: 'Phase is upcoming'
   },
   complete: {
     text: 'Complete',
-    className: 'bg-success/10 text-success border border-success/30',
+    className: 'border-success/30 bg-success/10 text-success',
     ariaLabel: 'Phase is complete'
   }
 };
@@ -38,11 +38,11 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
 
   return (
     <section aria-labelledby="phase-overview-heading" className="space-y-6">
-      <div className="flex items-center gap-3">
-        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+      <div className="flex items-start gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
           <CompassIcon className="h-6 w-6" />
         </div>
-        <div>
+        <div className="space-y-1">
           <h2 id="phase-overview-heading" className="text-xl font-semibold text-fg">
             Phase overview
           </h2>
@@ -58,12 +58,12 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
           return (
             <motion.article
               key={phase.key}
-              className="group flex h-full flex-col gap-5 rounded-2xl border border-border bg-card/95 p-6 shadow-glow transition focus-within:-translate-y-3"
-              whileHover={{ y: -12 }}
+              className="group flex h-full flex-col gap-5 rounded-2xl border border-border/80 bg-white p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg focus-within:-translate-y-1"
+              whileHover={{ y: -8 }}
             >
               <header className="flex items-start justify-between gap-4">
                 <div className="flex items-center gap-3">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
                     <Icon className="h-6 w-6" />
                   </div>
                   <div>
@@ -73,7 +73,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
                 </div>
                 <span
                   aria-label={badge.ariaLabel}
-                  className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium shadow-sm backdrop-blur ${badge.className}`}
+                  className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${badge.className}`}
                   role="status"
                 >
                   {badge.text}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -28,7 +28,7 @@ export function ProgressBar({ value, label }: ProgressBarProps) {
         </div>
       ) : null}
       <div
-        className="relative h-3 w-full overflow-hidden rounded-full bg-bg-elev"
+        className="relative h-3 w-full overflow-hidden rounded-full bg-border/50"
         role="progressbar"
         aria-label={label ?? 'Overall progress'}
         aria-valuenow={clampedValue}
@@ -36,16 +36,12 @@ export function ProgressBar({ value, label }: ProgressBarProps) {
         aria-valuemax={100}
       >
         <motion.div
-          className="relative h-full rounded-full bg-gradient-to-r from-primary via-accent to-primary-600 shadow-[0_0_15px_hsl(201_92%_56%/0.45)]"
+          className="relative h-full rounded-full bg-gradient-to-r from-primary via-accent to-primary-600 shadow-[0_6px_18px_rgba(59,130,246,0.25)]"
           style={style}
           initial={{ width: 0 }}
           animate={{ width: `${clampedValue}%` }}
           transition={reduceMotion ? { duration: 0 } : { duration: 1.1, ease: 'easeOut' }}
-        >
-          {!reduceMotion ? (
-            <span className="pointer-events-none absolute inset-0 -translate-x-full bg-[var(--shimmer)] opacity-70 mix-blend-screen animate-shimmer" />
-          ) : null}
-        </motion.div>
+        />
       </div>
     </div>
   );

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -38,58 +38,41 @@ const STATE_STYLES: Record<
 export function RoadToMainnet({ steps }: RoadToMainnetProps) {
   return (
     <section aria-labelledby="roadmap-heading" className="space-y-6">
-      <div className="flex items-center justify-between gap-4">
-        <div className="flex items-start gap-3">
-          <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/15 text-primary">
-            <TimelineIcon className="h-6 w-6" />
-          </div>
-          <div>
-            <h2 id="roadmap-heading" className="text-xl font-semibold text-fg">
-              Road to Mainnet
-            </h2>
-            <p className="text-sm text-fg-muted">
-              Milestones required to unlock mainnet launch readiness.
-            </p>
-          </div>
+      <div className="flex items-start gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+          <TimelineIcon className="h-6 w-6" />
         </div>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border bg-card/80 text-fg-muted transition hover:text-primary focus-visible:ring-2"
-            aria-label="Previous milestones"
-            disabled
-          >
-            <ChevronIcon className="h-4 w-4 rotate-180" />
-          </button>
-          <button
-            type="button"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border bg-card/80 text-fg-muted transition hover:text-primary focus-visible:ring-2"
-            aria-label="Next milestones"
-            disabled
-          >
-            <ChevronIcon className="h-4 w-4" />
-          </button>
+        <div className="space-y-1">
+          <h2 id="roadmap-heading" className="text-xl font-semibold text-fg">
+            Road to Mainnet
+          </h2>
+          <p className="text-sm text-fg-muted">
+            Milestones required to unlock mainnet launch readiness.
+          </p>
         </div>
       </div>
-      <ol className="relative space-y-6 border-l border-border/60 pl-6">
-        {steps.map((step) => {
-          const style = STATE_STYLES[step.state];
-          const Icon = style.icon;
-          return (
-            <li key={step.title} className="relative ml-1">
-              <div className="absolute -left-5 flex h-10 w-10 items-center justify-center rounded-full bg-primary/12 text-primary" aria-hidden="true">
-                <Icon className="h-5 w-5" />
-              </div>
-              <div className={`rounded-2xl border bg-card/95 p-5 shadow-glow ${style.border}`}>
-                <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold shadow-sm ${style.chip}`}>
-                  {style.label}
-                </span>
-                <h3 className="mt-3 text-lg font-semibold text-fg">{step.title}</h3>
-              </div>
-            </li>
-          );
-        })}
-      </ol>
+      <div className="rounded-2xl border border-border/80 bg-white p-6 shadow-soft">
+        <ol className="space-y-4">
+          {steps.map((step) => {
+            const style = STATE_STYLES[step.state];
+            const Icon = style.icon;
+            return (
+              <li key={step.title} className="flex flex-col gap-3 rounded-2xl border border-border/70 bg-bg p-4 text-sm text-fg">
+                <div className="flex items-center justify-between gap-3">
+                  <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${style.chip}`}>
+                    <span className="flex h-7 w-7 items-center justify-center rounded-full bg-white/70 text-primary shadow-soft" aria-hidden="true">
+                      <Icon className="h-4 w-4" />
+                    </span>
+                    {style.label}
+                  </span>
+                  <ChevronIcon className="h-4 w-4 text-fg-muted/80" aria-hidden="true" />
+                </div>
+                <h3 className="text-base font-semibold text-fg">{step.title}</h3>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
     </section>
   );
 }

--- a/src/components/SecurityAudits.tsx
+++ b/src/components/SecurityAudits.tsx
@@ -21,16 +21,16 @@ function StatCard({
 }) {
   const entries = Object.entries(metrics);
   return (
-    <article className="flex flex-1 flex-col gap-4 rounded-2xl border border-border bg-card/95 p-5 shadow-glow">
+    <article className="flex flex-1 flex-col gap-4 rounded-2xl border border-border/80 bg-white p-5 shadow-soft">
       <header className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/12 text-primary">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
           <Icon className="h-5 w-5" />
         </div>
         <h3 className="text-lg font-semibold text-fg">{title}</h3>
       </header>
       <dl className="grid grid-cols-2 gap-4 text-sm">
         {entries.map(([key, value]) => (
-          <div key={key} className="flex flex-col rounded-xl border border-border/70 bg-bg-elev/80 p-3 text-fg">
+          <div key={key} className="flex flex-col rounded-xl border border-border/70 bg-bg p-3 text-fg">
             <dt className="text-xs uppercase tracking-wide text-fg-muted/70">
               {STAT_LABELS[key] ?? key}
             </dt>
@@ -45,28 +45,26 @@ function StatCard({
 export function SecurityAudits({ notes, publicFindings, afterPriorityFixes }: SecurityAuditsProps) {
   return (
     <section aria-labelledby="security-heading" className="space-y-6">
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div className="flex items-start gap-3">
-          <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/15 text-primary">
-            <ShieldIcon className="h-6 w-6" />
-          </div>
-          <div>
-            <h2 id="security-heading" className="text-xl font-semibold text-fg">
-              Security &amp; audits
-            </h2>
-            <p className="text-sm text-fg-muted">
-              Highlights from recent reviews and what remains before mainnet readiness.
-            </p>
-          </div>
+      <div className="flex items-start gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+          <ShieldIcon className="h-6 w-6" />
+        </div>
+        <div className="space-y-1">
+          <h2 id="security-heading" className="text-xl font-semibold text-fg">
+            Security &amp; audits
+          </h2>
+          <p className="text-sm text-fg-muted">
+            Highlights from recent reviews and what remains before mainnet readiness.
+          </p>
         </div>
       </div>
       <div className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
-        <article className="rounded-2xl border border-border bg-card/95 p-6 shadow-glow">
+        <article className="rounded-2xl border border-border/80 bg-white p-6 shadow-soft">
           <h3 className="text-lg font-semibold text-fg">Security notes</h3>
           <ul className="mt-4 space-y-3 text-sm text-fg-muted">
             {notes.map((note) => (
               <li key={note} className="flex items-start gap-3">
-                <span aria-hidden="true" className="mt-0.5">
+                <span aria-hidden="true" className="mt-1">
                   <SparkIcon className="h-4 w-4 text-accent" />
                 </span>
                 <span>{note}</span>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,22 +1,20 @@
 :root {
   color-scheme: light dark;
-  --bg: hsl(0 0% 99%);
+  --bg: hsl(216 43% 97%);
   --bg-elev: hsl(0 0% 100%);
   --fg: hsl(222 47% 11%);
-  --fg-muted: hsl(222 20% 35%);
-  --primary: hsl(201 92% 56%);
-  --primary-600: hsl(201 92% 48%);
-  --accent: hsl(248 78% 68%);
+  --fg-muted: hsl(218 18% 42%);
+  --primary: hsl(217 91% 60%);
+  --primary-600: hsl(222 89% 55%);
+  --accent: hsl(249 83% 66%);
   --success: hsl(158 60% 40%);
-  --warning: hsl(45 100% 45%);
+  --warning: hsl(43 96% 54%);
   --danger: hsl(0 85% 50%);
-  --border: hsl(220 14% 90%);
+  --border: hsl(213 27% 86%);
   --ring: var(--primary);
   --card: hsl(0 0% 100%);
-  --shadow: 0 10px 30px hsl(220 60% 40% / 0.08);
-  --hero-gradient: radial-gradient(circle at 10% 20%, hsl(201 92% 62% / 0.25), transparent 55%),
-    radial-gradient(circle at 90% 10%, hsl(248 78% 65% / 0.22), transparent 50%),
-    radial-gradient(circle at 80% 80%, hsl(217 89% 64% / 0.15), transparent 55%);
+  --shadow: 0 22px 45px hsl(217 50% 50% / 0.08);
+  --hero-gradient: none;
   --shimmer: linear-gradient(
     120deg,
     transparent 0%,
@@ -29,16 +27,14 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: hsl(222 47% 6%);
-    --bg-elev: hsl(222 47% 8%);
+    --bg: hsl(222 47% 7%);
+    --bg-elev: hsl(222 47% 9%);
     --fg: hsl(0 0% 98%);
     --fg-muted: hsl(220 10% 70%);
-    --border: hsl(220 10% 20%);
-    --card: hsl(222 47% 8%);
-    --shadow: 0 10px 30px hsl(220 60% 10% / 0.5);
-    --hero-gradient: radial-gradient(circle at 10% 20%, hsl(201 92% 52% / 0.3), transparent 55%),
-      radial-gradient(circle at 90% 10%, hsl(248 78% 58% / 0.35), transparent 50%),
-      radial-gradient(circle at 70% 80%, hsl(217 88% 54% / 0.25), transparent 60%);
+    --border: hsl(220 10% 23%);
+    --card: hsl(222 47% 10%);
+    --shadow: 0 20px 45px hsl(220 60% 10% / 0.45);
+    --hero-gradient: none;
     --shimmer: linear-gradient(
       120deg,
       transparent 0%,

--- a/status.json
+++ b/status.json
@@ -15,9 +15,9 @@
     },
     {
       "key": "mainnet",
-      "title": "Zeinith",
+      "title": "Zenith",
       "status": "upcoming",
-      "summary": "Zeinith (Mainnet) follows Horizon stability and the final security competition."
+      "summary": "Zenith (Mainnet) follows Horizon stability and the final security competition."
     }
   ],
   "security": {
@@ -34,7 +34,7 @@
     { "title": "Relaunch Genesis", "state": "up_next" },
     { "title": "Launch Horizon", "state": "planned" },
     { "title": "Final audits & competition", "state": "planned" },
-    { "title": "Zeinith launch", "state": "planned" }
+    { "title": "Zenith launch", "state": "planned" }
   ],
   "links": {
     "governanceForum": "#",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const hasCustomDomain = fs.existsSync(path.resolve(__dirname, 'CNAME'));
+
 const repository = process.env.GITHUB_REPOSITORY;
 const repoName = repository?.split('/')[1]?.trim();
+const defaultBase = repoName ? `/${repoName}/` : '/tn-roadmap/';
 
-const base = repoName ? `/${repoName}/` : '/tn-roadmap/';
+const base = hasCustomDomain ? '/' : defaultBase;
 
 export default defineConfig(({ command }) => ({
   base: command === 'serve' ? '/' : base,


### PR DESCRIPTION
## Summary
- restyle the roadmap status page to match the provided design with a simplified hero and card-based sections
- refresh supporting components and theme tokens so cards, chips, and lists align with the new visual language

## Screenshot
![Updated Telcoin Network status page](browser:/invocations/sdbfzusy/artifacts/artifacts/roadmap.png)

## Testing
- npm run lint
- npm run build
- npm run validate:status

------
https://chatgpt.com/codex/tasks/task_e_68d57bb0272883309d5827f222197d73