### PR TITLE
feat: adopt Telcoin-inspired dark theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,13 +17,13 @@ const sectionVariants = {
 function SkeletonSection({ className }: { className?: string }) {
   return (
     <div
-      className={`animate-pulse rounded-2xl border border-border/60 bg-card/70 p-6 shadow-glow ${className ?? ''}`}
+      className={`animate-pulse rounded-2xl border border-border/60 bg-card p-6 shadow-glow backdrop-blur ${className ?? ''}`}
     >
-      <div className="h-4 w-32 rounded-full bg-bg-elev" />
+      <div className="h-4 w-32 rounded-full bg-white/10" />
       <div className="mt-4 space-y-3">
-        <div className="h-3 w-full rounded-full bg-bg-elev/80" />
-        <div className="h-3 w-5/6 rounded-full bg-bg-elev/70" />
-        <div className="h-3 w-2/3 rounded-full bg-bg-elev/60" />
+        <div className="h-3 w-full rounded-full bg-white/20" />
+        <div className="h-3 w-5/6 rounded-full bg-white/10" />
+        <div className="h-3 w-2/3 rounded-full bg-white/5" />
       </div>
     </div>
   );
@@ -31,10 +31,10 @@ function SkeletonSection({ className }: { className?: string }) {
 
 function HeaderSkeleton() {
   return (
-    <div className="animate-pulse space-y-4 rounded-3xl border border-border/60 bg-card/80 p-10 text-center shadow-glow">
-      <div className="mx-auto h-7 w-56 rounded-full bg-bg-elev" />
-      <div className="mx-auto h-4 w-64 rounded-full bg-bg-elev/80" />
-      <div className="mx-auto h-3 w-48 rounded-full bg-bg-elev/70" />
+    <div className="animate-pulse space-y-4 rounded-3xl border border-border/60 bg-card p-10 text-center shadow-glow backdrop-blur">
+      <div className="mx-auto h-7 w-56 rounded-full bg-white/15" />
+      <div className="mx-auto h-4 w-64 rounded-full bg-white/10" />
+      <div className="mx-auto h-3 w-48 rounded-full bg-white/5" />
     </div>
   );
 }
@@ -72,8 +72,8 @@ export default function App() {
     : 'Visibility into Telcoin Network progress and what remains before launch.';
 
   return (
-    <div className="min-h-screen bg-bg text-fg">
-      <header className="border-b border-border/70 bg-white/80 backdrop-blur">
+    <div className="min-h-screen bg-bg bg-hero-ambient text-fg">
+      <header className="border-b border-border/60 bg-card backdrop-blur">
         <div className="mx-auto max-w-5xl px-6 py-16 md:px-8">
           {showSkeleton ? (
             <HeaderSkeleton />
@@ -87,7 +87,7 @@ export default function App() {
             >
               <div className="flex flex-col items-center gap-6 text-center md:flex-row md:items-center md:justify-between md:text-left">
                 <div className="space-y-4">
-                  <span className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-primary">
+                  <span className="inline-flex items-center gap-2 rounded-full bg-primary/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-primary">
                     <NetworkIcon className="h-4 w-4" />
                     Telcoin Network
                   </span>
@@ -96,7 +96,7 @@ export default function App() {
                     <p className="max-w-xl text-base text-fg-muted md:text-lg">{headerDescription}</p>
                   </div>
                 </div>
-                <div className="w-full max-w-sm rounded-3xl border border-border/80 bg-white p-6 shadow-soft">
+                <div className="w-full max-w-sm rounded-3xl border border-border/70 bg-card p-6 shadow-soft backdrop-blur">
                   <ProgressBar value={status.meta.overallTrajectoryPct} label="Overall trajectory" />
                   <p className="mt-4 text-sm text-fg-muted">
                     Last updated <time dateTime={status.meta.lastUpdated}>{formattedLastUpdated}</time>
@@ -171,7 +171,7 @@ export default function App() {
           </>
         )}
       </main>
-      <footer className="border-t border-border/70 bg-white/90 py-8 text-center text-sm text-fg-muted">
+      <footer className="border-t border-border/60 bg-card py-8 text-center text-sm text-fg-muted backdrop-blur">
         © {new Date().getFullYear()} Telcoin Network — roadmap snapshot for engineering stakeholders.
       </footer>
     </div>

--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -38,7 +38,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
   return (
     <section aria-labelledby="learn-more-heading" className="space-y-6">
       <div className="flex items-start gap-3">
-        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/20 text-primary">
           <InfoIcon className="h-6 w-6" />
         </div>
         <div className="space-y-1">
@@ -57,7 +57,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
             <article
               key={question.id}
               id={`learn-more-${question.id}`}
-              className="overflow-hidden rounded-2xl border border-border/80 bg-white shadow-soft"
+              className="overflow-hidden rounded-2xl border border-border/70 bg-card shadow-soft backdrop-blur"
             >
               <motion.button
                 type="button"
@@ -68,7 +68,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
                 whileTap={{ scale: 0.99 }}
               >
                 <span className="flex items-center gap-3 text-base font-semibold text-fg">
-                  <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                  <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/20 text-primary">
                     <InfoIcon className="h-5 w-5" />
                   </span>
                   {question.title}
@@ -94,7 +94,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
         {linkButtons.map((link) => (
           <motion.a
             key={link.label}
-            className="inline-flex items-center gap-2 rounded-full border border-border/80 bg-white px-4 py-2 text-sm font-medium text-fg shadow-soft transition hover:-translate-y-0.5 hover:text-primary"
+            className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-fg shadow-soft backdrop-blur transition hover:-translate-y-0.5 hover:text-primary"
             href={link.href}
             target="_blank"
             rel="noreferrer noopener"

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -6,17 +6,17 @@ import { formatList } from '../utils/formatList';
 const STATUS_LABELS: Record<Phase['status'], { text: string; className: string; ariaLabel: string }> = {
   in_progress: {
     text: 'In progress',
-    className: 'border-primary/40 bg-primary/10 text-primary',
+    className: 'border-primary/50 bg-primary/20 text-primary',
     ariaLabel: 'Phase is in progress'
   },
   upcoming: {
     text: 'Upcoming',
-    className: 'border-border/60 bg-bg-elev text-fg-muted',
+    className: 'border-border/70 bg-white/10 text-fg-muted',
     ariaLabel: 'Phase is upcoming'
   },
   complete: {
     text: 'Complete',
-    className: 'border-success/30 bg-success/10 text-success',
+    className: 'border-success/40 bg-success/15 text-success',
     ariaLabel: 'Phase is complete'
   }
 };
@@ -39,7 +39,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
   return (
     <section aria-labelledby="phase-overview-heading" className="space-y-6">
       <div className="flex items-start gap-3">
-        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/20 text-primary">
           <CompassIcon className="h-6 w-6" />
         </div>
         <div className="space-y-1">
@@ -58,7 +58,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
           return (
             <motion.article
               key={phase.key}
-              className="group flex h-full flex-col gap-5 rounded-2xl border border-border/80 bg-white p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-lg focus-within:-translate-y-1"
+              className="group flex h-full flex-col gap-5 rounded-2xl border border-border/70 bg-card p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow focus-within:-translate-y-1"
               whileHover={{ y: -8 }}
             >
               <header className="flex items-start justify-between gap-4">

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -16,16 +16,16 @@ const STATE_STYLES: Record<
     chip: 'bg-primary/15 text-primary'
   },
   up_next: {
-    border: 'border-border',
+    border: 'border-border/80',
     label: 'Up next',
     icon: TimelineIcon,
-    chip: 'bg-bg-elev text-fg-muted'
+    chip: 'bg-white/10 text-fg-muted'
   },
   planned: {
     border: 'border-border/80',
     label: 'Planned',
     icon: NetworkIcon,
-    chip: 'bg-bg-elev/70 text-fg-muted'
+    chip: 'bg-white/5 text-fg-muted'
   },
   complete: {
     border: 'border-success/40',
@@ -39,7 +39,7 @@ export function RoadToMainnet({ steps }: RoadToMainnetProps) {
   return (
     <section aria-labelledby="roadmap-heading" className="space-y-6">
       <div className="flex items-start gap-3">
-        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/20 text-primary">
           <TimelineIcon className="h-6 w-6" />
         </div>
         <div className="space-y-1">
@@ -51,16 +51,19 @@ export function RoadToMainnet({ steps }: RoadToMainnetProps) {
           </p>
         </div>
       </div>
-      <div className="rounded-2xl border border-border/80 bg-white p-6 shadow-soft">
+      <div className="rounded-2xl border border-border/70 bg-card p-6 shadow-soft backdrop-blur">
         <ol className="space-y-4">
           {steps.map((step) => {
             const style = STATE_STYLES[step.state];
             const Icon = style.icon;
             return (
-              <li key={step.title} className="flex flex-col gap-3 rounded-2xl border border-border/70 bg-bg p-4 text-sm text-fg">
+              <li
+                key={step.title}
+                className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-fg backdrop-blur"
+              >
                 <div className="flex items-center justify-between gap-3">
                   <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${style.chip}`}>
-                    <span className="flex h-7 w-7 items-center justify-center rounded-full bg-white/70 text-primary shadow-soft" aria-hidden="true">
+                    <span className="flex h-7 w-7 items-center justify-center rounded-full bg-primary/15 text-primary shadow-soft" aria-hidden="true">
                       <Icon className="h-4 w-4" />
                     </span>
                     {style.label}

--- a/src/components/SecurityAudits.tsx
+++ b/src/components/SecurityAudits.tsx
@@ -21,17 +21,17 @@ function StatCard({
 }) {
   const entries = Object.entries(metrics);
   return (
-    <article className="flex flex-1 flex-col gap-4 rounded-2xl border border-border/80 bg-white p-5 shadow-soft">
+    <article className="flex flex-1 flex-col gap-4 rounded-2xl border border-border/70 bg-card p-5 shadow-soft backdrop-blur">
       <header className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/20 text-primary">
           <Icon className="h-5 w-5" />
         </div>
         <h3 className="text-lg font-semibold text-fg">{title}</h3>
       </header>
       <dl className="grid grid-cols-2 gap-4 text-sm">
         {entries.map(([key, value]) => (
-          <div key={key} className="flex flex-col rounded-xl border border-border/70 bg-bg p-3 text-fg">
-            <dt className="text-xs uppercase tracking-wide text-fg-muted/70">
+          <div key={key} className="flex flex-col rounded-xl border border-white/10 bg-white/5 p-3 text-fg backdrop-blur">
+            <dt className="text-xs uppercase tracking-wide text-fg-muted">
               {STAT_LABELS[key] ?? key}
             </dt>
             <dd className="text-xl font-semibold text-fg">{value}</dd>
@@ -46,7 +46,7 @@ export function SecurityAudits({ notes, publicFindings, afterPriorityFixes }: Se
   return (
     <section aria-labelledby="security-heading" className="space-y-6">
       <div className="flex items-start gap-3">
-        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/20 text-primary">
           <ShieldIcon className="h-6 w-6" />
         </div>
         <div className="space-y-1">
@@ -59,7 +59,7 @@ export function SecurityAudits({ notes, publicFindings, afterPriorityFixes }: Se
         </div>
       </div>
       <div className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
-        <article className="rounded-2xl border border-border/80 bg-white p-6 shadow-soft">
+        <article className="rounded-2xl border border-border/70 bg-card p-6 shadow-soft backdrop-blur">
           <h3 className="text-lg font-semibold text-fg">Security notes</h3>
           <ul className="mt-4 space-y-3 text-sm text-fg-muted">
             {notes.map((note) => (

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,18 @@
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
   body {
-    @apply bg-bg text-fg antialiased transition-colors duration-300 ease-out;
+    @apply bg-bg text-fg antialiased transition-colors duration-300 ease-out font-sans;
+    background-color: var(--bg);
+    background-image: var(--hero-gradient);
+    background-attachment: fixed;
+    background-repeat: no-repeat;
+    background-size: cover;
+    font-feature-settings: 'ss01' on, 'ss03' on;
   }
 
   a {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,53 +1,37 @@
 :root {
-  color-scheme: light dark;
-  --bg: hsl(216 43% 97%);
-  --bg-elev: hsl(0 0% 100%);
-  --fg: hsl(222 47% 11%);
-  --fg-muted: hsl(218 18% 42%);
-  --primary: hsl(217 91% 60%);
-  --primary-600: hsl(222 89% 55%);
-  --accent: hsl(249 83% 66%);
-  --success: hsl(158 60% 40%);
-  --warning: hsl(43 96% 54%);
-  --danger: hsl(0 85% 50%);
-  --border: hsl(213 27% 86%);
-  --ring: var(--primary);
-  --card: hsl(0 0% 100%);
-  --shadow: 0 22px 45px hsl(217 50% 50% / 0.08);
-  --hero-gradient: none;
+  color-scheme: dark;
+  --bg: hsl(233 73% 11%);
+  --bg-elev: hsl(232 66% 15%);
+  --fg: hsl(214 100% 97%);
+  --fg-muted: hsl(220 28% 78%);
+  --primary: hsl(191 94% 62%);
+  --primary-600: hsl(191 88% 55%);
+  --accent: hsl(263 87% 72%);
+  --success: hsl(157 76% 48%);
+  --warning: hsl(43 95% 62%);
+  --danger: hsl(2 80% 62%);
+  --border: hsl(230 53% 28%);
+  --ring: hsl(191 94% 62%);
+  --card: hsla(232, 66%, 17%, 0.88);
+  --shadow: 0 32px 60px hsl(225 80% 16% / 0.45);
+  --hero-gradient: radial-gradient(
+      circle at 10% 20%,
+      hsl(255 88% 64% / 0.65),
+      transparent 55%
+    ),
+    linear-gradient(135deg, hsl(248 74% 15%), hsl(214 86% 21%), hsl(194 83% 36%));
   --shimmer: linear-gradient(
     120deg,
     transparent 0%,
     hsl(0 0% 100% / 0),
-    hsl(0 0% 100% / 0.4) 40%,
-    hsl(0 0% 100% / 0) 70%,
+    hsl(0 0% 100% / 0.35) 45%,
+    hsl(0 0% 100% / 0) 75%,
     transparent 100%
   );
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: hsl(222 47% 7%);
-    --bg-elev: hsl(222 47% 9%);
-    --fg: hsl(0 0% 98%);
-    --fg-muted: hsl(220 10% 70%);
-    --border: hsl(220 10% 23%);
-    --card: hsl(222 47% 10%);
-    --shadow: 0 20px 45px hsl(220 60% 10% / 0.45);
-    --hero-gradient: none;
-    --shimmer: linear-gradient(
-      120deg,
-      transparent 0%,
-      hsl(0 0% 100% / 0),
-      hsl(0 0% 100% / 0.25) 45%,
-      hsl(0 0% 100% / 0) 75%,
-      transparent 100%
-    );
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   :root {
-    --shadow: 0 12px 24px hsl(220 60% 40% / 0.06);
+    --shadow: 0 18px 36px hsl(225 80% 16% / 0.32);
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,6 +4,9 @@ const config: Config = {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['"Manrope"', 'system-ui', 'sans-serif']
+      },
       colors: {
         bg: 'var(--bg)',
         'bg-elev': 'var(--bg-elev)',


### PR DESCRIPTION
## Summary
- restyle the global theme with a Telcoin-inspired gradient palette and Manrope typography
- refresh roadmap cards, chips, and skeletons with glassmorphism overlays that read on the new dark background

## Screenshots
![Updated Telcoin-inspired dark theme](browser:/invocations/kouckkwl/artifacts/artifacts/roadmap-dark-theme.png)

## Test Plan
- npm ci && npm run dev
- npm run lint
- npm run build
- npm run validate:status

------
https://chatgpt.com/codex/tasks/task_e_68d597b9a8c48330b7c0ffb80dfd1ae3