### PR TITLE
Enhance typography and card outlines

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ const sectionVariants = {
 function SkeletonSection({ className }: { className?: string }) {
   return (
     <div
-      className={`animate-pulse rounded-2xl border border-border/60 bg-card p-6 shadow-glow backdrop-blur ${className ?? ''}`}
+      className={`animate-pulse rounded-2xl border-2 border-border/60 bg-card p-6 shadow-glow backdrop-blur ${className ?? ''}`}
     >
       <div className="h-4 w-32 rounded-full bg-white/10" />
       <div className="mt-4 space-y-3">
@@ -31,7 +31,7 @@ function SkeletonSection({ className }: { className?: string }) {
 
 function HeaderSkeleton() {
   return (
-    <div className="animate-pulse space-y-4 rounded-3xl border border-border/60 bg-card p-10 text-center shadow-glow backdrop-blur">
+    <div className="animate-pulse space-y-4 rounded-3xl border-2 border-border/60 bg-card p-10 text-center shadow-glow backdrop-blur">
       <div className="mx-auto h-7 w-56 rounded-full bg-white/15" />
       <div className="mx-auto h-4 w-64 rounded-full bg-white/10" />
       <div className="mx-auto h-3 w-48 rounded-full bg-white/5" />
@@ -73,7 +73,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-bg bg-hero-ambient text-fg">
-      <header className="border-b border-border/60 bg-card backdrop-blur">
+      <header className="border-b-2 border-border/60 bg-card backdrop-blur">
         <div className="mx-auto max-w-5xl px-6 py-16 md:px-8">
           {showSkeleton ? (
             <HeaderSkeleton />
@@ -92,11 +92,11 @@ export default function App() {
                     Telcoin Network
                   </span>
                   <div className="space-y-3">
-                    <h1 className="text-3xl font-semibold text-fg md:text-4xl">Telcoin Network Status</h1>
+                    <h1 className="text-3xl font-extrabold text-fg md:text-4xl">Telcoin Network Status</h1>
                     <p className="max-w-xl text-base text-fg-muted md:text-lg">{headerDescription}</p>
                   </div>
                 </div>
-                <div className="w-full max-w-sm rounded-3xl border border-border/70 bg-card p-6 shadow-soft backdrop-blur">
+                <div className="w-full max-w-sm rounded-3xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
                   <ProgressBar value={status.meta.overallTrajectoryPct} label="Overall trajectory" />
                   <p className="mt-4 text-sm text-fg-muted">
                     Last updated <time dateTime={status.meta.lastUpdated}>{formattedLastUpdated}</time>
@@ -171,7 +171,7 @@ export default function App() {
           </>
         )}
       </main>
-      <footer className="border-t border-border/60 bg-card py-8 text-center text-sm text-fg-muted backdrop-blur">
+      <footer className="border-t-2 border-border/60 bg-card py-8 text-center text-sm text-fg-muted backdrop-blur">
         © {new Date().getFullYear()} Telcoin Network — roadmap snapshot for engineering stakeholders.
       </footer>
     </div>

--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -9,8 +9,8 @@ type LearnMoreProps = {
 };
 
 export function LearnMore({ phases, links }: LearnMoreProps) {
-  const defaultOpenId = phases[0]?.key ?? 'devnet';
-  const [openId, setOpenId] = useState<Phase['key']>(defaultOpenId);
+  const defaultOpenId = phases[0]?.key ?? null;
+  const [openId, setOpenId] = useState<Phase['key'] | null>(defaultOpenId);
   useEffect(() => {
     setOpenId(defaultOpenId);
   }, [defaultOpenId]);
@@ -26,7 +26,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
   );
 
   const toggle = (id: Phase['key']) => {
-    setOpenId(id);
+    setOpenId((current) => (current === id ? null : id));
   };
 
   const linkButtons = [
@@ -42,7 +42,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
           <InfoIcon className="h-6 w-6" />
         </div>
         <div className="space-y-1">
-          <h2 id="learn-more-heading" className="text-xl font-semibold text-fg">
+          <h2 id="learn-more-heading" className="text-xl font-bold text-fg">
             Learn more
           </h2>
           <p className="text-sm text-fg-muted">
@@ -57,7 +57,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
             <article
               key={question.id}
               id={`learn-more-${question.id}`}
-              className="overflow-hidden rounded-2xl border border-border/70 bg-card shadow-soft backdrop-blur"
+              className="overflow-hidden rounded-2xl border-2 border-border/60 bg-card shadow-soft backdrop-blur"
             >
               <motion.button
                 type="button"

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -43,7 +43,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
           <CompassIcon className="h-6 w-6" />
         </div>
         <div className="space-y-1">
-          <h2 id="phase-overview-heading" className="text-xl font-semibold text-fg">
+          <h2 id="phase-overview-heading" className="text-xl font-bold text-fg">
             Phase overview
           </h2>
           <p className="text-sm text-fg-muted">
@@ -58,7 +58,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
           return (
             <motion.article
               key={phase.key}
-              className="group flex h-full flex-col gap-5 rounded-2xl border border-border/70 bg-card p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow focus-within:-translate-y-1"
+              className="group flex h-full flex-col gap-5 rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow focus-within:-translate-y-1"
               whileHover={{ y: -8 }}
             >
               <header className="flex items-start justify-between gap-4">

--- a/src/components/RoadToDeployment/Flow.tsx
+++ b/src/components/RoadToDeployment/Flow.tsx
@@ -74,7 +74,7 @@ function RoadmapNode({ data }: NodeProps<FlowNodeData>) {
         onMouseLeave={() => toggleHover(false)}
         onFocus={() => toggleHover(true)}
         onBlur={() => toggleHover(false)}
-        className={`flex min-w-[220px] flex-col gap-3 rounded-2xl border bg-card p-4 text-left shadow-glow transition duration-200 ease-out focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${statusStyle} hover:-translate-y-1 hover:border-primary/50 hover:shadow-[0_25px_55px_-25px_hsl(201_92%_56%/0.45)]`}
+        className={`flex min-w-[220px] flex-col gap-3 rounded-2xl border-2 bg-card p-4 text-left shadow-glow transition duration-200 ease-out focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${statusStyle} hover:-translate-y-1 hover:border-primary/50 hover:shadow-[0_25px_55px_-25px_hsl(201_92%_56%/0.45)]`}
       >
         <span className="text-xs font-semibold uppercase tracking-[0.2em] text-fg-muted/80">
           {phase.subtitle ?? 'Milestone'}
@@ -214,14 +214,14 @@ export function RoadToDeploymentFlow({ onSelectPhase }: FlowProps) {
         <p className="text-xs font-semibold uppercase tracking-[0.35em] text-fg-muted/70">Deployment journey</p>
         <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
           <div className="space-y-2">
-            <h2 id="roadmap-flow-heading" className="text-2xl font-semibold text-fg">
+            <h2 id="roadmap-flow-heading" className="text-2xl font-bold text-fg">
               Road to deployment
             </h2>
             <p className="max-w-2xl text-sm text-fg-muted">
               Follow how Genesis, Horizon, and Zenith flow from critical fixes into live deployment.
             </p>
           </div>
-          <div className="max-w-xs rounded-2xl border border-border bg-card p-4 shadow-glow">
+          <div className="max-w-xs rounded-2xl border-2 border-border bg-card p-4 shadow-glow">
             <div className="flex items-center justify-between text-xs font-medium text-fg-muted">
               <span>Overall readiness</span>
               <span className="text-sm font-semibold text-fg">{progress}%</span>
@@ -239,7 +239,7 @@ export function RoadToDeploymentFlow({ onSelectPhase }: FlowProps) {
         </div>
       </header>
       <div
-        className="rounded-3xl border border-border/60 bg-card/80 p-6 shadow-glow h-[32rem] md:h-[26rem]"
+        className="rounded-3xl border-2 border-border/60 bg-card/80 p-6 shadow-glow h-[32rem] md:h-[26rem]"
         data-testid="roadmap-flow"
       >
         <ReactFlow

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -43,7 +43,7 @@ export function RoadToMainnet({ steps }: RoadToMainnetProps) {
           <TimelineIcon className="h-6 w-6" />
         </div>
         <div className="space-y-1">
-          <h2 id="roadmap-heading" className="text-xl font-semibold text-fg">
+          <h2 id="roadmap-heading" className="text-xl font-bold text-fg">
             Road to Mainnet
           </h2>
           <p className="text-sm text-fg-muted">
@@ -51,7 +51,7 @@ export function RoadToMainnet({ steps }: RoadToMainnetProps) {
           </p>
         </div>
       </div>
-      <div className="rounded-2xl border border-border/70 bg-card p-6 shadow-soft backdrop-blur">
+      <div className="rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
         <ol className="space-y-4">
           {steps.map((step) => {
             const style = STATE_STYLES[step.state];
@@ -59,7 +59,7 @@ export function RoadToMainnet({ steps }: RoadToMainnetProps) {
             return (
               <li
                 key={step.title}
-                className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-fg backdrop-blur"
+                className="flex flex-col gap-3 rounded-2xl border-2 border-white/10 bg-white/5 p-4 text-sm text-fg backdrop-blur"
               >
                 <div className="flex items-center justify-between gap-3">
                   <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${style.chip}`}>

--- a/src/components/SecurityAudits.tsx
+++ b/src/components/SecurityAudits.tsx
@@ -21,7 +21,7 @@ function StatCard({
 }) {
   const entries = Object.entries(metrics);
   return (
-    <article className="flex flex-1 flex-col gap-4 rounded-2xl border border-border/70 bg-card p-5 shadow-soft backdrop-blur">
+    <article className="flex flex-1 flex-col gap-4 rounded-2xl border-2 border-border/60 bg-card p-5 shadow-soft backdrop-blur">
       <header className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/20 text-primary">
           <Icon className="h-5 w-5" />
@@ -50,7 +50,7 @@ export function SecurityAudits({ notes, publicFindings, afterPriorityFixes }: Se
           <ShieldIcon className="h-6 w-6" />
         </div>
         <div className="space-y-1">
-          <h2 id="security-heading" className="text-xl font-semibold text-fg">
+          <h2 id="security-heading" className="text-xl font-bold text-fg">
             Security &amp; audits
           </h2>
           <p className="text-sm text-fg-muted">
@@ -59,7 +59,7 @@ export function SecurityAudits({ notes, publicFindings, afterPriorityFixes }: Se
         </div>
       </div>
       <div className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
-        <article className="rounded-2xl border border-border/70 bg-card p-6 shadow-soft backdrop-blur">
+        <article className="rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
           <h3 className="text-lg font-semibold text-fg">Security notes</h3>
           <ul className="mt-4 space-y-3 text-sm text-fg-muted">
             {notes.map((note) => (

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 
 @tailwind base;
 @tailwind components;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,7 +5,7 @@ const config: Config = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['"Manrope"', 'system-ui', 'sans-serif']
+        sans: ['"Inter"', 'system-ui', 'sans-serif']
       },
       colors: {
         bg: 'var(--bg)',


### PR DESCRIPTION
## Summary
- switch the global typeface to Inter with updated font weights for key headings
- thicken the borders on roadmap cards and panels for clearer visual separation
- allow Learn more accordions to close when re-clicked for consistent interactions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5a29f5a788324a9816a51079d0970