### PR TITLE
Centralize section copy and update phase overview summaries

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { ProgressBar } from './components/ProgressBar';
 import { RoadToMainnet } from './components/RoadToMainnet';
 import { SecurityAudits } from './components/SecurityAudits';
 import { loadStatus, type Status } from './data/loadStatus';
+import { SECTION_COPY } from './data/sectionCopy';
 import { formatList } from './utils/formatList';
 
 const sectionVariants = {
@@ -66,9 +67,7 @@ export default function App() {
   const showSkeleton = status === null;
   const phaseTitles = status?.phases.map((phase) => phase.title) ?? [];
   const readablePhaseList = formatList(phaseTitles);
-  const headerDescription = readablePhaseList
-    ? `Visibility into our ${readablePhaseList} progress and what remains before launch.`
-    : 'Visibility into Telcoin Network progress and what remains before launch.';
+  const headerDescription = SECTION_COPY.header.descriptionTemplate(readablePhaseList);
 
   return (
     <div className="min-h-screen bg-bg bg-hero-ambient text-fg">
@@ -86,7 +85,7 @@ export default function App() {
             >
               <div className="flex flex-col items-center gap-6 text-center md:flex-row md:items-start md:justify-between md:text-left">
                 <div className="space-y-3">
-                  <h1 className="text-3xl font-extrabold text-fg md:text-4xl">Telcoin Network Status</h1>
+                  <h1 className="text-3xl font-extrabold text-fg md:text-4xl">{SECTION_COPY.header.title}</h1>
                   <p className="max-w-xl text-base text-fg-muted md:text-lg">{headerDescription}</p>
                 </div>
                 <div className="w-full max-w-sm rounded-3xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">

--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
 import type { Phase, Status } from '../data/statusSchema';
 import { ChevronIcon, ExternalLinkIcon, InfoIcon } from './icons';
+import { SECTION_COPY } from '../data/sectionCopy';
 
 type LearnMoreProps = {
   phases: Phase[];
@@ -21,7 +22,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
   }, Object.create(null));
 
   const questions = useMemo(
-    () => phases.map((phase) => ({ id: phase.key, title: `What is ${phase.title}?` })),
+    () => phases.map((phase) => ({ id: phase.key, title: SECTION_COPY.learnMore.questionTemplate(phase.title) })),
     [phases]
   );
 
@@ -43,17 +44,15 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
         </div>
         <div className="space-y-1">
           <h2 id="learn-more-heading" className="text-xl font-bold text-fg">
-            Learn more
+            {SECTION_COPY.learnMore.heading}
           </h2>
-          <p className="text-sm text-fg-muted">
-            Dive deeper into each network phase and the documentation supporting the roadmap.
-          </p>
+          <p className="text-sm text-fg-muted">{SECTION_COPY.learnMore.description}</p>
         </div>
       </div>
       <div className="space-y-4">
         {questions.map((question) => {
           const isOpen = openId === question.id;
-          const content = (summaries[question.id] ?? 'Details coming soon.').split('\n\n');
+          const content = (summaries[question.id] ?? SECTION_COPY.learnMore.defaultSummary).split('\n\n');
           return (
             <article
               key={question.id}

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -2,6 +2,7 @@ import { motion } from 'framer-motion';
 import type { Phase } from '../data/statusSchema';
 import { CompassIcon, LaunchIcon, MainnetIcon, NetworkIcon, TestnetIcon } from './icons';
 import { formatList } from '../utils/formatList';
+import { SECTION_COPY } from '../data/sectionCopy';
 
 const STATUS_LABELS: Record<Phase['status'], { text: string; className: string; ariaLabel: string }> = {
   in_progress: {
@@ -44,10 +45,10 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
         </div>
         <div className="space-y-1">
           <h2 id="phase-overview-heading" className="text-xl font-bold text-fg">
-            Phase overview
+            {SECTION_COPY.phaseOverview.heading}
           </h2>
           <p className="text-sm text-fg-muted">
-            Track where Telcoin Network stands across {phaseListText}.
+            {SECTION_COPY.phaseOverview.descriptionTemplate(phaseListText)}
           </p>
         </div>
       </div>

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -1,5 +1,6 @@
 import type { RoadmapItem } from '../data/statusSchema';
 import { ChevronIcon, LaunchIcon, NetworkIcon, TimelineIcon } from './icons';
+import { SECTION_COPY } from '../data/sectionCopy';
 
 type RoadToMainnetProps = {
   steps: RoadmapItem[];
@@ -44,11 +45,9 @@ export function RoadToMainnet({ steps }: RoadToMainnetProps) {
         </div>
         <div className="space-y-1">
           <h2 id="roadmap-heading" className="text-xl font-bold text-fg">
-            Road to Mainnet
+            {SECTION_COPY.roadmap.heading}
           </h2>
-          <p className="text-sm text-fg-muted">
-            Milestones required to unlock mainnet launch readiness.
-          </p>
+          <p className="text-sm text-fg-muted">{SECTION_COPY.roadmap.description}</p>
         </div>
       </div>
       <div className="rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">

--- a/src/components/SecurityAudits.tsx
+++ b/src/components/SecurityAudits.tsx
@@ -1,5 +1,6 @@
 import type { Status } from '../data/statusSchema';
 import { NetworkIcon, ShieldIcon, SparkIcon } from './icons';
+import { SECTION_COPY } from '../data/sectionCopy';
 
 type SecurityAuditsProps = Pick<Status['security'], 'notes' | 'publicFindings' | 'afterPriorityFixes'>;
 
@@ -51,16 +52,14 @@ export function SecurityAudits({ notes, publicFindings, afterPriorityFixes }: Se
         </div>
         <div className="space-y-1">
           <h2 id="security-heading" className="text-xl font-bold text-fg">
-            Security &amp; audits
+            {SECTION_COPY.security.heading}
           </h2>
-          <p className="text-sm text-fg-muted">
-            Highlights from recent reviews and what remains before mainnet readiness.
-          </p>
+          <p className="text-sm text-fg-muted">{SECTION_COPY.security.description}</p>
         </div>
       </div>
       <div className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
         <article className="rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
-          <h3 className="text-lg font-semibold text-fg">Security notes</h3>
+          <h3 className="text-lg font-semibold text-fg">{SECTION_COPY.security.noteHeading}</h3>
           <ul className="mt-4 space-y-3 text-sm text-fg-muted">
             {notes.map((note) => (
               <li key={note} className="flex items-start gap-3">
@@ -73,8 +72,16 @@ export function SecurityAudits({ notes, publicFindings, afterPriorityFixes }: Se
           </ul>
         </article>
         <div className="flex flex-col gap-4">
-          <StatCard title="Priority Findings (public-facing)" metrics={publicFindings} icon={NetworkIcon} />
-          <StatCard title="After Priority Fixes (remaining)" metrics={afterPriorityFixes} icon={ShieldIcon} />
+          <StatCard
+            title={SECTION_COPY.security.priorityFindingsTitle}
+            metrics={publicFindings}
+            icon={NetworkIcon}
+          />
+          <StatCard
+            title={SECTION_COPY.security.afterPriorityFixesTitle}
+            metrics={afterPriorityFixes}
+            icon={ShieldIcon}
+          />
         </div>
       </div>
     </section>

--- a/src/data/sectionCopy.ts
+++ b/src/data/sectionCopy.ts
@@ -1,0 +1,35 @@
+export const SECTION_COPY = {
+  header: {
+    title: 'Telcoin Network Status',
+    descriptionTemplate: (phaseList: string) =>
+      phaseList
+        ? `Visibility into our ${phaseList} progress and what remains before launch.`
+        : 'Visibility into Telcoin Network progress and what remains before launch.'
+  },
+  phaseOverview: {
+    heading: 'Phase overview',
+    descriptionTemplate: (phaseList: string) =>
+      `Track where Telcoin Network stands across ${phaseList || 'each network phase'}.`
+  },
+  security: {
+    heading: 'Security & audits',
+    description:
+      'Highlights from recent reviews and what remains before mainnet readiness.',
+    noteHeading: 'Security notes',
+    priorityFindingsTitle: 'Priority Findings (public-facing)',
+    afterPriorityFixesTitle: 'After Priority Fixes (remaining)'
+  },
+  roadmap: {
+    heading: 'Road to Mainnet',
+    description: 'Milestones required to unlock mainnet launch readiness.'
+  },
+  learnMore: {
+    heading: 'Learn more',
+    description:
+      'Dive deeper into each network phase and the documentation supporting the roadmap.',
+    questionTemplate: (title: string) => `What is ${title}?`,
+    defaultSummary: 'Details coming soon.'
+  }
+} as const;
+
+export type SectionCopy = typeof SECTION_COPY;

--- a/status.json
+++ b/status.json
@@ -5,19 +5,19 @@
       "key": "devnet",
       "title": "Genesis",
       "status": "in_progress",
-      "summary": "Genesis is the name for the Telcoin Network’s development environment (previously called Devnet). It’s where new features, protocol upgrades, and network improvements are first deployed and tested by the core engineering team.\n\nAt this stage, the focus is on fixing the last set of high-priority security findings and validating that all the moving parts of the network perform as expected. Genesis isn’t designed for public use—it’s primarily an internal proving ground—but it plays a critical role in unblocking progress to the next stage, Horizon. Once Genesis reaches stability, the network will be ready for broader testing with external partners."
+      "summary": "Fixing the final high-priority security issues before relaunching Genesis (formerly Devnet) to unblock Horizon."
     },
     {
       "key": "testnet",
       "title": "Horizon",
       "status": "upcoming",
-      "summary": "Horizon is the Telcoin Network’s public testnet, where the community and partners—including mobile network operators (MNOs) spinning up validator nodes—can interact with the network in a live but non-production setting.\n\nThis stage follows Genesis stabilization and will roll out in phases. Early iterations of Horizon may still see instability or bugs as the network undergoes continuous upgrades and audit cycles. That’s intentional: Horizon is where real-world testing happens, and where we make sure validator participation, governance mechanics, and protocol updates all function securely before moving to mainnet.\n\nHorizon represents a critical milestone because it’s the first time the broader ecosystem—validators, developers, and community members—can meaningfully engage with the Telcoin Network."
+      "summary": "Launching after Genesis stabilizes. Early Horizon iterations may be unstable until audits complete."
     },
     {
       "key": "mainnet",
       "title": "Zenith",
       "status": "upcoming",
-      "summary": "Zenith is the name for the Telcoin Network’s mainnet launch—the culmination of the Genesis and Horizon phases. Once Horizon has achieved stability and passed the final rounds of audits and the open security competition, the network will transition to Zenith.\n\nZenith represents the full public launch of the Telcoin Network, where validators, developers, and users can rely on the system for real value transfer and application deployment. It’s the point at which the network moves from testing to production, with the security and decentralization guarantees expected of a Layer 1 blockchain."
+      "summary": "Zenith (Mainnet) follows Horizon stability and the final security competition."
     }
   ],
   "security": {


### PR DESCRIPTION
## Summary
- centralize section text into a shared `SECTION_COPY` data module so each section’s copy can be edited independently
- update components to read their headings and descriptions from the new shared copy source without altering the layout
- refresh phase overview summaries in `status.json` with the latest Genesis, Horizon, and Zenith messaging

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5cbcecf7c83309ced11c67adca521