### PR TITLE
Add dedicated Learn more copy for each network phase

### DIFF
--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -16,8 +16,8 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
     setOpenId(defaultOpenId);
   }, [defaultOpenId]);
 
-  const summaries = phases.reduce<Record<Phase['key'], string>>((acc, phase) => {
-    acc[phase.key] = phase.summary;
+  const details = phases.reduce<Record<Phase['key'], string>>((acc, phase) => {
+    acc[phase.key] = phase.learnMore ?? phase.summary;
     return acc;
   }, Object.create(null));
 
@@ -52,7 +52,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
       <div className="space-y-4">
         {questions.map((question) => {
           const isOpen = openId === question.id;
-          const content = (summaries[question.id] ?? SECTION_COPY.learnMore.defaultSummary).split('\n\n');
+          const content = (details[question.id] ?? SECTION_COPY.learnMore.defaultSummary).split('\n\n');
           return (
             <article
               key={question.id}

--- a/src/data/statusSchema.ts
+++ b/src/data/statusSchema.ts
@@ -22,7 +22,8 @@ export const statusSchema = z.object({
         key: z.enum(['devnet', 'testnet', 'mainnet']),
         title: z.string().min(1),
         status: phaseStatusSchema,
-        summary: z.string().min(1)
+        summary: z.string().min(1),
+        learnMore: z.string().min(1)
       })
     )
     .length(3),

--- a/status.json
+++ b/status.json
@@ -5,19 +5,22 @@
       "key": "devnet",
       "title": "Genesis",
       "status": "in_progress",
-      "summary": "Fixing the final high-priority security issues before relaunching Genesis (formerly Devnet) to unblock Horizon."
+      "summary": "Fixing the final high-priority security issues before relaunching Genesis (formerly Devnet) to unblock Horizon.",
+      "learnMore": "Genesis is the name for the Telcoin Network’s development environment (previously called Devnet). It’s where new features, protocol upgrades, and network improvements are first deployed and tested by the core engineering team.\n\nAt this stage, the focus is on fixing the last set of high-priority security findings and validating that all the moving parts of the network perform as expected. Genesis isn’t designed for public use—it’s primarily an internal proving ground—but it plays a critical role in unblocking progress to the next stage, Horizon. Once Genesis reaches stability, the network will be ready for broader testing with external partners."
     },
     {
       "key": "testnet",
       "title": "Horizon",
       "status": "upcoming",
-      "summary": "Launching after Genesis stabilizes. Early Horizon iterations may be unstable until audits complete."
+      "summary": "Launching after Genesis stabilizes. Early Horizon iterations may be unstable until audits complete.",
+      "learnMore": "Horizon is the Telcoin Network’s public testnet, where the community and partners—including mobile network operators (MNOs) spinning up validator nodes—can interact with the network in a live but non-production setting.\n\nThis stage follows Genesis stabilization and will roll out in phases. Early iterations of Horizon may still see instability or bugs as the network undergoes continuous upgrades and audit cycles. That’s intentional: Horizon is where real-world testing happens, and where we make sure validator participation, governance mechanics, and protocol updates all function securely before moving to mainnet.\n\nHorizon represents a critical milestone because it’s the first time the broader ecosystem—validators, developers, and community members—can meaningfully engage with the Telcoin Network."
     },
     {
       "key": "mainnet",
       "title": "Zenith",
       "status": "upcoming",
-      "summary": "Zenith (Mainnet) follows Horizon stability and the final security competition."
+      "summary": "Zenith (Mainnet) follows Horizon stability and the final security competition.",
+      "learnMore": "Zenith is the name for the Telcoin Network’s mainnet launch—the culmination of the Genesis and Horizon phases. Once Horizon has achieved stability and passed the final rounds of audits and the open security competition, the network will transition to Zenith.\n\nZenith represents the full public launch of the Telcoin Network, where validators, developers, and users can rely on the system for real value transfer and application deployment. It’s the point at which the network moves from testing to production, with the security and decentralization guarantees expected of a Layer 1 blockchain."
     }
   ],
   "security": {


### PR DESCRIPTION
## Summary
- allow the Learn more accordion to pull dedicated copy instead of reusing phase summaries
- populate Genesis, Horizon, and Zenith Learn more entries with the latest long-form descriptions

## Testing
- npm run validate:status

------
https://chatgpt.com/codex/tasks/task_e_68d64ab5a00883248a568e42cf3fc4ff