### PR TITLE
Rename network phases to Horizon, Adiri, and Mainnet

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -38,6 +38,7 @@ export function ProgressBar({ value, label }: ProgressBarProps) {
         aria-valuemax={100}
       >
         <motion.div
+          key={clampedValue}
           className="progress-fill relative h-full rounded-full bg-gradient-to-r from-primary via-accent to-primary-600 shadow-[0_6px_18px_rgba(59,130,246,0.25)]"
           style={style}
           data-pulsing={microEnabled && clampedValue > 0 ? 'true' : undefined}

--- a/src/components/RoadToDeployment/Flow.tsx
+++ b/src/components/RoadToDeployment/Flow.tsx
@@ -218,7 +218,7 @@ export function RoadToDeploymentFlow({ onSelectPhase }: FlowProps) {
               Road to deployment
             </h2>
             <p className="max-w-2xl text-sm text-fg-muted">
-              Follow how Genesis, Horizon, and Zenith flow from critical fixes into live deployment.
+              Follow how Horizon (Devnet), Adiri (Testnet), and Mainnet flow from critical fixes into live deployment.
             </p>
           </div>
           <div className="max-w-xs rounded-2xl border-2 border-border bg-card p-4 shadow-glow">

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -18,25 +18,25 @@ export const ROADMAP: Phase[] = [
     status: 'in_progress',
     description: 'Address all high/medium findings; backfilled unit + integration tests.',
     metrics: { high: 0, medium: 14, low: 36 },
-    links: [{ label: 'Review Genesis context', href: '#learn-more-devnet' }]
+    links: [{ label: 'Review Horizon (Devnet) context', href: '#learn-more-devnet' }]
   },
   {
     id: 'genesis',
-    title: 'Relaunch Genesis',
+    title: 'Relaunch Horizon',
     subtitle: 'Devnet relaunch',
     status: 'up_next',
-    description: 'Stabilize Genesis to unblock Horizon relaunch.',
+    description: 'Stabilize Horizon (Devnet) to unblock Adiri rollout.',
     dependsOn: ['fixes'],
-    links: [{ label: 'See Genesis readiness', href: '#learn-more-devnet' }]
+    links: [{ label: 'See Horizon readiness', href: '#learn-more-devnet' }]
   },
   {
     id: 'horizon',
-    title: 'Launch Horizon',
+    title: 'Launch Adiri',
     subtitle: 'Public Testnet',
     status: 'planned',
-    description: 'Early iterations guarded; audits complete.',
+    description: 'Early Adiri iterations guarded; audits complete.',
     dependsOn: ['genesis'],
-    links: [{ label: 'Review Horizon plan', href: '#learn-more-testnet' }]
+    links: [{ label: 'Review Adiri plan', href: '#learn-more-testnet' }]
   },
   {
     id: 'audits',
@@ -48,11 +48,11 @@ export const ROADMAP: Phase[] = [
   },
   {
     id: 'zenith',
-    title: 'Zenith launch',
+    title: 'Mainnet launch',
     subtitle: 'Mainnet readiness',
     status: 'planned',
     description: 'Mainnet launch after competition sign-off.',
     dependsOn: ['audits'],
-    links: [{ label: 'Learn about Zenith', href: '#learn-more-mainnet' }]
+    links: [{ label: 'Learn about Mainnet', href: '#learn-more-mainnet' }]
   }
 ];

--- a/src/utils/__tests__/formatList.test.ts
+++ b/src/utils/__tests__/formatList.test.ts
@@ -7,18 +7,18 @@ describe('formatList', () => {
   });
 
   it('returns single item unchanged', () => {
-    expect(formatList(['Genesis'])).toBe('Genesis');
+    expect(formatList(['Horizon'])).toBe('Horizon');
   });
 
   it('joins two items with and', () => {
-    expect(formatList(['Genesis', 'Horizon'])).toBe('Genesis and Horizon');
+    expect(formatList(['Horizon', 'Adiri'])).toBe('Horizon and Adiri');
   });
 
   it('joins more than two items with commas and and', () => {
-    expect(formatList(['Genesis', 'Horizon', 'Zeinith'])).toBe('Genesis, Horizon, and Zeinith');
+    expect(formatList(['Horizon', 'Adiri', 'Mainnet'])).toBe('Horizon, Adiri, and Mainnet');
   });
 
   it('ignores blank strings', () => {
-    expect(formatList(['Genesis', ' ', 'Zeinith'])).toBe('Genesis and Zeinith');
+    expect(formatList(['Horizon', ' ', 'Mainnet'])).toBe('Horizon and Mainnet');
   });
 });

--- a/status.json
+++ b/status.json
@@ -1,26 +1,26 @@
 {
-  "meta": { "lastUpdated": "2025-09-23T19:00:00Z", "overallTrajectoryPct": 25 },
+  "meta": { "lastUpdated": "2025-09-26T16:38:37Z", "overallTrajectoryPct": 25 },
   "phases": [
     {
       "key": "devnet",
-      "title": "Genesis",
+      "title": "Horizon",
       "status": "in_progress",
-      "summary": "Fixing the final high-priority security issues before relaunching Genesis (formerly Devnet) to unblock Horizon.",
-      "learnMore": "Genesis is the name for the Telcoin Network’s development environment (previously called Devnet). It’s where new features, protocol upgrades, and network improvements are first deployed and tested by the core engineering team.\n\nAt this stage, the focus is on fixing the last set of high-priority security findings and validating that all the moving parts of the network perform as expected. Genesis isn’t designed for public use—it’s primarily an internal proving ground—but it plays a critical role in unblocking progress to the next stage, Horizon. Once Genesis reaches stability, the network will be ready for broader testing with external partners."
+      "summary": "Fixing the final high-priority security issues before relaunching Horizon (Devnet, formerly Genesis) to unblock Adiri.",
+      "learnMore": "Horizon is the Telcoin Network’s development environment—the space formerly known as Genesis or Devnet. It’s where new features, protocol upgrades, and network improvements are first deployed and tested by the core engineering team.\n\nAt this stage, the focus is on fixing the last set of high-priority security findings and validating that all the moving parts of the network perform as expected. Horizon isn’t designed for public use—it’s primarily an internal proving ground—but it plays a critical role in unblocking progress to the next stage, Adiri. Once Horizon reaches stability, the network will be ready for broader testing with external partners."
     },
     {
       "key": "testnet",
-      "title": "Horizon",
+      "title": "Adiri",
       "status": "upcoming",
-      "summary": "Launching after Genesis stabilizes. Early Horizon iterations may be unstable until audits complete.",
-      "learnMore": "Horizon is the Telcoin Network’s public testnet, where the community and partners—including mobile network operators (MNOs) spinning up validator nodes—can interact with the network in a live but non-production setting.\n\nThis stage follows Genesis stabilization and will roll out in phases. Early iterations of Horizon may still see instability or bugs as the network undergoes continuous upgrades and audit cycles. That’s intentional: Horizon is where real-world testing happens, and where we make sure validator participation, governance mechanics, and protocol updates all function securely before moving to mainnet.\n\nHorizon represents a critical milestone because it’s the first time the broader ecosystem—validators, developers, and community members—can meaningfully engage with the Telcoin Network."
+      "summary": "Launching after Horizon (Devnet) stabilizes. Early Adiri iterations may be unstable until audits complete.",
+      "learnMore": "Adiri is the Telcoin Network’s public testnet, where the community and partners—including mobile network operators (MNOs) spinning up validator nodes—can interact with the network in a live but non-production setting. Formerly called Horizon, Adiri follows Horizon (Devnet) stabilization and will roll out in phases.\n\nEarly iterations of Adiri may still see instability or bugs as the network undergoes continuous upgrades and audit cycles. That’s intentional: Adiri is where real-world testing happens, and where we make sure validator participation, governance mechanics, and protocol updates all function securely before moving to mainnet.\n\nAdiri represents a critical milestone because it’s the first time the broader ecosystem—validators, developers, and community members—can meaningfully engage with the Telcoin Network."
     },
     {
       "key": "mainnet",
-      "title": "Zenith",
+      "title": "Mainnet",
       "status": "upcoming",
-      "summary": "Zenith (Mainnet) follows Horizon stability and the final security competition.",
-      "learnMore": "Zenith is the name for the Telcoin Network’s mainnet launch—the culmination of the Genesis and Horizon phases. Once Horizon has achieved stability and passed the final rounds of audits and the open security competition, the network will transition to Zenith.\n\nZenith represents the full public launch of the Telcoin Network, where validators, developers, and users can rely on the system for real value transfer and application deployment. It’s the point at which the network moves from testing to production, with the security and decentralization guarantees expected of a Layer 1 blockchain."
+      "summary": "Mainnet launch follows Adiri stability and the final security competition.",
+      "learnMore": "Mainnet is the culmination of the Horizon (Devnet) and Adiri (Testnet) phases—formerly referred to as Zenith. Once Adiri has achieved stability and passed the final rounds of audits and the open security competition, the network will transition to Mainnet.\n\nMainnet represents the full public launch of the Telcoin Network, where validators, developers, and users can rely on the system for real value transfer and application deployment. It’s the point at which the network moves from testing to production, with the security and decentralization guarantees expected of a Layer 1 blockchain."
     }
   ],
   "security": {
@@ -39,14 +39,14 @@
       "details": "Fix remaining vulnerabilities"
     },
     {
-      "title": "Relaunch Genesis",
+      "title": "Relaunch Horizon",
       "state": "up_next",
-      "details": "Relaunch Genesis"
+      "details": "Relaunch Horizon (Devnet)"
     },
     {
-      "title": "Launch Horizon",
+      "title": "Launch Adiri",
       "state": "planned",
-      "details": "Launch Horizon"
+      "details": "Launch Adiri (Testnet)"
     },
     {
       "title": "Final audits & competition",
@@ -54,9 +54,9 @@
       "details": "Final audits & competition"
     },
     {
-      "title": "Zenith launch",
+      "title": "Mainnet launch",
       "state": "planned",
-      "details": "Zenith launch"
+      "details": "Mainnet launch"
     }
   ],
   "links": {


### PR DESCRIPTION
## Summary
- rename network phase content to Horizon (Devnet), Adiri (Testnet), and Mainnet across status data and roadmap copy
- refresh the visible roadmap description to reference the new phase names and update the status timestamp
- ensure the progress bar re-animates when progress values change

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c12077608324a7215effd0d2b1af