### PR TITLE
Refine starfield typings for bundler builds

### DIFF
--- a/src/background/starfield.d.ts
+++ b/src/background/starfield.d.ts
@@ -1,3 +1,3 @@
-declare module './background/starfield.js' {
-  export function initStarfield(): () => void;
-}
+export type StarfieldCleanup = () => void;
+
+export const initStarfield: () => StarfieldCleanup;


### PR DESCRIPTION
## Summary
- adjust the starfield ambient declaration to export a const function signature so TypeScript recognizes the module during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6dd349fe08330bada33cda2fe1d37