### PR TITLE
Reduce vertical spacing of layout padding

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -24,4 +24,17 @@
   a:focus-visible {
     @apply outline-none ring-2 ring-offset-2 ring-offset-bg;
   }
+
+  header > div:first-of-type,
+  main.mx-auto {
+    padding-block: 2.4rem;
+  }
+}
+
+@layer utilities {
+  main.mx-auto > :not([hidden]) ~ :not([hidden]) {
+    --space-y-vertical: 2.4rem;
+    margin-top: calc(var(--space-y-vertical) * (1 - var(--tw-space-y-reverse, 0)));
+    margin-bottom: calc(var(--space-y-vertical) * var(--tw-space-y-reverse, 0));
+  }
 }


### PR DESCRIPTION
## Summary
- reduce the header and main container padding to achieve a 40% shorter vertical footprint
- tighten the spacing between main sections to match the reduced vertical rhythm

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6ef1c0b8c83309e847a2a76c75d95