### PR TITLE
Add password gate overlay for roadmap preview

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import App from './App';
 import './styles/theme.css';
 import './index.css';
 import './styles/microinteractions.css';
+import './styles/password-gate.css';
 
 const rootElement = document.getElementById('root');
 
@@ -11,8 +12,128 @@ if (!rootElement) {
   throw new Error('Failed to find the root element');
 }
 
-ReactDOM.createRoot(rootElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+const ACCESS_TOKEN_STORAGE_KEY = 'tn-roadmap::access-granted';
+const PASSWORD = 'association1!$';
+
+const renderApp = () => {
+  ReactDOM.createRoot(rootElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+};
+
+const isAccessGranted = () => {
+  try {
+    return window.sessionStorage.getItem(ACCESS_TOKEN_STORAGE_KEY) === 'true';
+  } catch (error) {
+    return false;
+  }
+};
+
+const showPasswordGate = () => {
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+  const overlay = document.createElement('div');
+  overlay.id = 'password-gate-overlay';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.setAttribute('aria-labelledby', 'password-gate-title');
+  overlay.setAttribute('aria-describedby', 'password-gate-description password-gate-error');
+
+  const container = document.createElement('div');
+  container.className = 'password-gate';
+  container.tabIndex = -1;
+
+  const title = document.createElement('h1');
+  title.className = 'password-gate__title';
+  title.id = 'password-gate-title';
+  title.textContent = 'Restricted access';
+
+  const description = document.createElement('p');
+  description.className = 'password-gate__description';
+  description.id = 'password-gate-description';
+  description.textContent =
+    'This preview is currently protected. Enter the access password to continue.';
+
+  const form = document.createElement('form');
+  form.className = 'password-gate__form';
+  form.setAttribute('aria-labelledby', 'password-gate-title');
+  form.setAttribute('aria-describedby', 'password-gate-description password-gate-error');
+  form.noValidate = true;
+
+  const label = document.createElement('label');
+  label.className = 'password-gate__label';
+  label.htmlFor = 'password-gate-input';
+
+  const labelText = document.createElement('span');
+  labelText.textContent = 'Password';
+
+  const input = document.createElement('input');
+  input.className = 'password-gate__input';
+  input.id = 'password-gate-input';
+  input.name = 'password';
+  input.type = 'password';
+  input.required = true;
+  input.autocomplete = 'current-password';
+  input.setAttribute('aria-required', 'true');
+
+  const submit = document.createElement('button');
+  submit.className = 'password-gate__submit';
+  submit.type = 'submit';
+  submit.textContent = 'Unlock';
+
+  const error = document.createElement('p');
+  error.className = 'password-gate__error';
+  error.id = 'password-gate-error';
+  error.textContent = 'Incorrect password. Please try again.';
+  error.setAttribute('role', 'status');
+  error.setAttribute('aria-live', 'assertive');
+  error.hidden = true;
+
+  label.append(labelText, input);
+  form.append(label, submit);
+  container.append(title, description, form, error);
+  overlay.append(container);
+  document.body.append(overlay);
+
+  const originalOverflow = document.body.style.overflow;
+  document.body.style.overflow = 'hidden';
+  container.focus();
+
+  requestAnimationFrame(() => {
+    input.focus();
+  });
+
+  const revealError = () => {
+    error.hidden = false;
+  };
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const value = input.value.trim();
+
+    if (value === PASSWORD) {
+      window.sessionStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, 'true');
+      overlay.remove();
+      document.body.style.overflow = originalOverflow;
+      previouslyFocused?.focus?.();
+      renderApp();
+    } else {
+      revealError();
+      input.value = '';
+      input.focus();
+    }
+  });
+
+  input.addEventListener('input', () => {
+    if (!error.hidden) {
+      error.hidden = true;
+    }
+  });
+};
+
+if (isAccessGranted()) {
+  renderApp();
+} else {
+  showPasswordGate();
+}

--- a/src/styles/password-gate.css
+++ b/src/styles/password-gate.css
@@ -1,0 +1,96 @@
+#password-gate-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: rgba(12, 13, 18, 0.88);
+  background: color-mix(in srgb, var(--surface, rgba(12, 13, 18, 0.9)) 70%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.password-gate {
+  width: min(100%, 420px);
+  border-radius: 1rem;
+  background: var(--card, rgba(12, 13, 18, 0.95));
+  color: inherit;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+  padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.password-gate__title {
+  font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  font-weight: 600;
+  margin: 0;
+}
+
+.password-gate__description {
+  margin: 0;
+  color: var(--muted, rgba(255, 255, 255, 0.75));
+  line-height: 1.5;
+}
+
+.password-gate__form {
+  display: grid;
+  gap: 1rem;
+}
+
+.password-gate__label {
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 500;
+}
+
+.password-gate__input {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.75rem;
+  background: rgba(17, 18, 24, 0.9);
+  padding: 0.75rem 1rem;
+  color: inherit;
+  font: inherit;
+}
+
+.password-gate__input:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.password-gate__submit {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  background: var(--accent, #5d5af5);
+  color: var(--fg, #fff);
+  font: inherit;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.password-gate__submit:hover,
+.password-gate__submit:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(93, 90, 245, 0.35);
+  outline: none;
+}
+
+.password-gate__error {
+  margin: 0;
+  color: #ff7a7a;
+  font-size: 0.95rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #password-gate-overlay {
+    backdrop-filter: none;
+  }
+
+  .password-gate__submit {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- gate the roadmap preview behind a password prompt that stores access in sessionStorage
- inject an accessible full-screen overlay until the correct password is provided
- add dedicated styles for the password gate with visible focus and reduced motion fallbacks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7217d5e0c8330aaa1e4126ca914a0