### PR TITLE
Reposition footer links and tighten phase card spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,24 +233,6 @@ export default function App() {
       <footer className="border-t-2 border-border/60 bg-card py-8 text-sm text-fg-muted backdrop-blur">
         <div className="mx-auto flex max-w-5xl flex-col items-center gap-4 px-6 text-center md:flex-row md:justify-between md:px-8 md:text-left">
           <span>© 2025 Telcoin Network</span>
-          <div className="flex flex-wrap justify-center gap-2">
-            <a
-              className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card px-4 py-2 font-semibold text-fg transition-transform transition-colors duration-200 ease-out hover:-translate-y-0.5 hover:bg-primary/10 hover:text-primary focus-visible:-translate-y-0.5"
-              href="https://x.com/TelcoinTAO"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              TelcoinTAO on X
-            </a>
-            <a
-              className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card px-4 py-2 font-semibold text-fg transition-transform transition-colors duration-200 ease-out hover:-translate-y-0.5 hover:bg-primary/10 hover:text-primary focus-visible:-translate-y-0.5"
-              href="https://www.telcoin.org/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Telcoin Association
-            </a>
-          </div>
         </div>
       </footer>
     </div>

--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -33,6 +33,8 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
   const linkButtons = [
     { label: 'Governance Forum', href: links.governanceForum },
     { label: 'Technical Docs', href: links.technicalDocs },
+    { label: 'TelcoinTAO on X', href: 'https://x.com/TelcoinTAO' },
+    { label: 'Telcoin Association', href: 'https://www.telcoin.org/' },
     { label: 'Faucet', href: 'https://www.telcoin.network/faucet' }
   ];
 

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -65,9 +65,10 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
               key={phase.key}
               className="group flex h-full flex-col gap-4 rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow focus-within:-translate-y-1"
               whileHover={{ y: -8 }}
+              data-phase-card
             >
-              <header className="flex items-start justify-between gap-4">
-                <div className="flex items-center gap-3">
+              <header className="flex items-start justify-between gap-4" data-phase-card-header>
+                <div className="flex items-center gap-3" data-phase-card-title-group>
                   <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
                     <Icon className="h-6 w-6" />
                   </div>

--- a/src/index.css
+++ b/src/index.css
@@ -38,3 +38,27 @@
     margin-bottom: calc(var(--space-y-vertical) * var(--tw-space-y-reverse, 0));
   }
 }
+
+@layer components {
+  [data-phase-card] {
+    gap: 0.75rem;
+    padding-block: 1.25rem;
+  }
+
+  [data-phase-card-header] {
+    align-items: center;
+  }
+
+  [data-phase-card-title-group] {
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  [data-phase-card-title-group] h3 {
+    margin-bottom: 0.125rem;
+  }
+
+  [data-phase-card-title-group] p {
+    margin-top: 0;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,7 +26,7 @@ const renderApp = () => {
 const isAccessGranted = () => {
   try {
     return window.sessionStorage.getItem(ACCESS_TOKEN_STORAGE_KEY) === 'true';
-  } catch (error) {
+  } catch {
     return false;
   }
 };


### PR DESCRIPTION
## Summary
- move the TelcoinTAO and Telcoin Association links into the Learn More call-to-action group so they sit with the other resource buttons
- tighten the phase overview cards by adding data hooks and component-level CSS adjustments for improved vertical alignment
- update the password gate storage guard to satisfy linting rules while preserving behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7caf5b66883249745cfb192f664b4