### PR TITLE
Adjust PhaseOverview card alignment

### DIFF
--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -57,7 +57,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-3 items-stretch">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3 items-start">
         {phases.map((phase) => {
           const badge = STATUS_LABELS[phase.status];
           const Icon = PHASE_ICONS[phase.key] ?? NetworkIcon;


### PR DESCRIPTION
## Summary
- adjust PhaseOverview grid alignment to start items at the top

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8111bd62883248f601d653638dc06