### PR TITLE
Adjust phase card footer spacing

### DIFF
--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -104,7 +104,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
                   {phase.summary}
                 </p>
 
-                <div className="mt-auto pt-2 md:pt-4" data-phase-card-footer>
+                <div className="pt-2 md:pt-4" data-phase-card-footer>
                   <a
                     className="inline-flex items-center text-[0.58rem] font-semibold text-primary transition hover:text-primary/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary md:text-xs"
                     href={phase.learnMore}


### PR DESCRIPTION
## Summary
- remove the `mt-auto` utility from the phase card footer so the cards shrink to their intrinsic height while preserving padding

## Testing
- Manual verification in browser (Vite dev server, inspected desktop and mobile breakpoints)


------
https://chatgpt.com/codex/tasks/task_e_68d819d082b88324850d7f30515b51fe