### PR TITLE
Add Playwright E2E workflow

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,0 +1,44 @@
+name: E2E (Playwright)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright (browsers + system deps)
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npx playwright test
+        env:
+          FORCE_COLOR: "1"
+
+      - name: Upload Playwright report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run Playwright end-to-end tests on pushes and pull requests
- install dependencies, set up Playwright browsers, execute tests, and upload reports on failure

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d81d658aa48330a536fe061cb4eb9c