### PR TITLE
Refresh roadmap naming and interactions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import { ProgressBar } from './components/ProgressBar';
 import { RoadToMainnet } from './components/RoadToMainnet';
 import { SecurityAudits } from './components/SecurityAudits';
 import { loadStatus, type Status } from './data/loadStatus';
-import { formatList } from './utils/formatList';
 
 const sectionVariants = {
   hidden: { opacity: 0, y: 24 },
@@ -64,11 +63,8 @@ export default function App() {
   }, [status]);
 
   const showSkeleton = status === null;
-  const phaseTitles = status?.phases.map((phase) => phase.title) ?? [];
-  const readablePhaseList = formatList(phaseTitles);
-  const headerDescription = readablePhaseList
-    ? `Visibility into our ${readablePhaseList} progress and what remains before launch.`
-    : 'Visibility into Telcoin Network progress and what remains before launch.';
+  const headerDescription =
+    'Visibility into our Horizon, Adiri, and Mainnet progress and what remains before launch.';
 
   return (
     <div className="min-h-screen bg-bg bg-hero-ambient text-fg">
@@ -86,8 +82,8 @@ export default function App() {
             >
               <div className="flex flex-col items-center gap-6 text-center md:flex-row md:items-start md:justify-between md:text-left">
                 <div className="space-y-3">
-                  <h1 className="text-3xl font-extrabold text-fg md:text-4xl">Telcoin Network Status</h1>
-                  <p className="max-w-xl text-base text-fg-muted md:text-lg">{headerDescription}</p>
+                  <h1 className="text-2xl font-extrabold text-fg md:text-3xl">Telcoin Network Status</h1>
+                  <p className="max-w-xl text-sm text-fg-muted md:text-base">{headerDescription}</p>
                 </div>
                 <div className="w-full max-w-sm rounded-3xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
                   <ProgressBar value={status.meta.overallTrajectoryPct} label="Overall trajectory" />

--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -8,22 +8,47 @@ type LearnMoreProps = {
   links: Status['links'];
 };
 
+const LEARN_MORE_CONTENT: Record<Phase['key'], { title: string; body: string[] }> = {
+  devnet: {
+    title: 'What is Horizon',
+    body: [
+      "Horizon is the name for the Telcoin Network’s development environment (previously called Devnet). It’s where new features, protocol upgrades, and network improvements are first deployed and tested by the core engineering team.",
+      "At this stage, the focus is on fixing the last set of high-priority security findings and validating that all the moving parts of the network perform as expected. Horizon isn’t designed for public use—it’s primarily an internal proving ground—but it plays a critical role in unblocking progress to the next stage, Adiri. Once Horizon reaches stability, the network will be ready for broader testing with external partners."
+    ]
+  },
+  testnet: {
+    title: 'What is Adiri',
+    body: [
+      'Adiri is the Telcoin Network’s public testnet, where the community and partners—including mobile network operators (MNOs) spinning up validator nodes—can interact with the network in a live but non-production setting.',
+      'This stage follows Horizon stabilization and will roll out in phases. Early iterations of Adiri may still see instability or bugs as the network undergoes continuous upgrades and audit cycles. That’s intentional: Adiri is where real-world testing happens, and where we make sure validator participation, governance mechanics, and protocol updates all function securely before moving to mainnet.',
+      'Adiri represents a critical milestone because it’s the first time the broader ecosystem—validators, developers, and community members—can meaningfully engage with the Telcoin Network.'
+    ]
+  },
+  mainnet: {
+    title: 'What is Mainnet',
+    body: [
+      'Mainnet is the name for the Telcoin Network’s mainnet launch—the culmination of the Horizon and Adiri phases. Once Adiri has achieved stability and passed the final rounds of audits and the open security competition, the network will transition to Mainnet.',
+      'Mainnet represents the full public launch of the Telcoin Network, where validators, developers, and users can rely on the system for real value transfer and application deployment. It’s the point at which the network moves from testing to production, with the security and decentralization guarantees expected of a Layer 1 blockchain.'
+    ]
+  }
+};
+
 export function LearnMore({ phases, links }: LearnMoreProps) {
-  const defaultOpenId = phases[0]?.key ?? null;
+  const orderedSections = useMemo(() => phases.map((phase) => ({ key: phase.key, status: phase.status })), [phases]);
+  const defaultOpenId = useMemo(() => {
+    const activePhase = orderedSections.find((section) => section.status === 'in_progress');
+    return activePhase?.key ?? orderedSections[0]?.key ?? null;
+  }, [orderedSections]);
   const [openId, setOpenId] = useState<Phase['key'] | null>(defaultOpenId);
   useEffect(() => {
     setOpenId(defaultOpenId);
   }, [defaultOpenId]);
 
-  const summaries = phases.reduce<Record<Phase['key'], string>>((acc, phase) => {
-    acc[phase.key] = phase.summary;
-    return acc;
-  }, Object.create(null));
-
-  const questions = useMemo(
-    () => phases.map((phase) => ({ id: phase.key, title: `What is ${phase.title}?` })),
-    [phases]
-  );
+  const sections = orderedSections.map((section) => ({
+    id: section.key,
+    title: LEARN_MORE_CONTENT[section.key]?.title ?? 'Learn more',
+    body: LEARN_MORE_CONTENT[section.key]?.body ?? ['Details coming soon.']
+  }));
 
   const toggle = (id: Phase['key']) => {
     setOpenId((current) => (current === id ? null : id));
@@ -32,7 +57,9 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
   const linkButtons = [
     { label: 'Governance Forum', href: links.governanceForum },
     { label: 'Technical Docs', href: links.technicalDocs },
-    { label: 'Faucet', href: 'https://www.telcoin.network/faucet' }
+    { label: 'Faucet', href: 'https://www.telcoin.network/faucet' },
+    { label: 'Telcoin Association', href: 'https://www.telcoin.org/' },
+    { label: 'Telcoin TAO Twitter', href: 'https://x.com/TelcoinTAO' }
   ];
 
   return (
@@ -51,40 +78,42 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
         </div>
       </div>
       <div className="space-y-4">
-        {questions.map((question) => {
-          const isOpen = openId === question.id;
+        {sections.map((section) => {
+          const isOpen = openId === section.id;
           return (
             <article
-              key={question.id}
-              id={`learn-more-${question.id}`}
+              key={section.id}
+              id={`learn-more-${section.id}`}
               className="overflow-hidden rounded-2xl border-2 border-border/60 bg-card shadow-soft backdrop-blur"
             >
               <motion.button
                 type="button"
                 className="flex w-full items-center justify-between gap-4 px-6 py-4 text-left focus-visible:outline-none"
                 aria-expanded={isOpen}
-                aria-controls={`${question.id}-panel`}
-                onClick={() => toggle(question.id)}
+                aria-controls={`${section.id}-panel`}
+                onClick={() => toggle(section.id)}
                 whileTap={{ scale: 0.99 }}
               >
                 <span className="flex items-center gap-3 text-base font-semibold text-fg">
                   <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/20 text-primary">
                     <InfoIcon className="h-5 w-5" />
                   </span>
-                  {question.title}
+                  {section.title}
                 </span>
                 <span aria-hidden="true" className={`transition-transform ${isOpen ? 'rotate-90' : ''}`}>
                   <ChevronIcon className="h-4 w-4" />
                 </span>
               </motion.button>
               <div
-                id={`${question.id}-panel`}
+                id={`${section.id}-panel`}
                 role="region"
                 aria-live="polite"
                 aria-hidden={!isOpen}
-                className={`px-6 pb-6 text-sm leading-relaxed text-fg-muted transition-[max-height,opacity] duration-300 ease-out ${isOpen ? 'max-h-60 opacity-100' : 'max-h-0 opacity-0'}`}
+                className={`space-y-4 px-6 pb-6 text-sm leading-relaxed text-fg-muted transition-[max-height,opacity] duration-300 ease-out ${isOpen ? 'max-h-[720px] opacity-100' : 'max-h-0 opacity-0'}`}
               >
-                {summaries[question.id] ?? 'Details coming soon.'}
+                {section.body.map((paragraph, index) => (
+                  <p key={index}>{paragraph}</p>
+                ))}
               </div>
             </article>
           );

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -1,13 +1,14 @@
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import type { Phase } from '../data/statusSchema';
 import { CompassIcon, LaunchIcon, MainnetIcon, NetworkIcon, TestnetIcon } from './icons';
 import { formatList } from '../utils/formatList';
 
-const STATUS_LABELS: Record<Phase['status'], { text: string; className: string; ariaLabel: string }> = {
+const STATUS_LABELS: Record<Phase['status'], { text: string; className: string; ariaLabel: string; shouldPulse?: boolean }> = {
   in_progress: {
     text: 'In progress',
     className: 'border-primary/50 bg-primary/20 text-primary',
-    ariaLabel: 'Phase is in progress'
+    ariaLabel: 'Phase is in progress',
+    shouldPulse: true
   },
   upcoming: {
     text: 'Upcoming',
@@ -27,6 +28,12 @@ const PHASE_ICONS: Partial<Record<Phase['key'], typeof NetworkIcon>> = {
   mainnet: MainnetIcon
 };
 
+const PHASE_CODE_NAMES: Record<Phase['key'], string> = {
+  devnet: 'Horizon',
+  testnet: 'Adiri',
+  mainnet: 'Mainnet'
+};
+
 type PhaseOverviewProps = {
   phases: Phase[];
 };
@@ -35,6 +42,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
   const phaseTitles = phases.map((phase) => phase.title);
   const readablePhaseList = formatList(phaseTitles);
   const phaseListText = readablePhaseList || 'each network phase';
+  const reduceMotion = useReducedMotion();
 
   return (
     <section aria-labelledby="phase-overview-heading" className="space-y-6">
@@ -68,16 +76,26 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
                   </div>
                   <div>
                     <h3 className="text-lg font-semibold text-fg">{phase.title}</h3>
-                    <p className="text-xs uppercase tracking-[0.2em] text-fg-muted/70">{phase.key}</p>
+                    <p className="text-xs uppercase tracking-[0.2em] text-fg-muted/70">
+                      {PHASE_CODE_NAMES[phase.key]}
+                    </p>
                   </div>
                 </div>
-                <span
+                <motion.span
                   aria-label={badge.ariaLabel}
                   className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${badge.className}`}
                   role="status"
+                  animate={
+                    !reduceMotion && badge.shouldPulse ? { opacity: [1, 0.5, 1] } : undefined
+                  }
+                  transition={
+                    !reduceMotion && badge.shouldPulse
+                      ? { duration: 1.2, repeat: Infinity, repeatType: 'reverse', ease: 'easeInOut' }
+                      : undefined
+                  }
                 >
                   {badge.text}
-                </span>
+                </motion.span>
               </header>
               <p className="text-sm leading-relaxed text-fg-muted transition group-hover:text-fg">
                 {phase.summary}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -20,11 +20,8 @@ export function ProgressBar({ value, label }: ProgressBarProps) {
   return (
     <div className="space-y-2">
       {label ? (
-        <div className="flex items-center justify-between text-sm text-fg-muted">
+        <div className="text-sm font-medium text-fg-muted">
           <span>{label}</span>
-          <span className="font-medium text-fg">
-            {clampedValue}%
-          </span>
         </div>
       ) : null}
       <div
@@ -38,9 +35,20 @@ export function ProgressBar({ value, label }: ProgressBarProps) {
         <motion.div
           className="relative h-full rounded-full bg-gradient-to-r from-primary via-accent to-primary-600 shadow-[0_6px_18px_rgba(59,130,246,0.25)]"
           style={style}
-          initial={{ width: 0 }}
-          animate={{ width: `${clampedValue}%` }}
-          transition={reduceMotion ? { duration: 0 } : { duration: 1.1, ease: 'easeOut' }}
+          initial={{ width: 0, opacity: 1 }}
+          animate={
+            reduceMotion
+              ? { width: `${clampedValue}%`, opacity: 1 }
+              : { width: `${clampedValue}%`, opacity: [1, 0.65, 1] }
+          }
+          transition={
+            reduceMotion
+              ? { duration: 0 }
+              : {
+                  width: { duration: 1.1, ease: 'easeOut' },
+                  opacity: { duration: 1.5, repeat: Infinity, repeatType: 'reverse', ease: 'easeInOut' }
+                }
+          }
         />
       </div>
     </div>

--- a/status.json
+++ b/status.json
@@ -3,21 +3,21 @@
   "phases": [
     {
       "key": "devnet",
-      "title": "Genesis",
+      "title": "Horizon",
       "status": "in_progress",
-      "summary": "Fixing the final high-priority security issues before relaunching Genesis (formerly Devnet) to unblock Horizon."
+      "summary": "Finalizing high-priority security fixes and validating the Horizon development environment ahead of broader testing."
     },
     {
       "key": "testnet",
-      "title": "Horizon",
+      "title": "Adiri",
       "status": "upcoming",
-      "summary": "Launching after Genesis stabilizes. Early Horizon iterations may be unstable until audits complete."
+      "summary": "Preparing the Adiri public testnet so partners and community validators can exercise the network in a live setting."
     },
     {
       "key": "mainnet",
-      "title": "Zenith",
+      "title": "Mainnet",
       "status": "upcoming",
-      "summary": "Zenith (Mainnet) follows Horizon stability and the final security competition."
+      "summary": "Planning the Mainnet launch once Adiri is stable and the final audits and security competition are complete."
     }
   ],
   "security": {
@@ -31,10 +31,10 @@
   },
   "roadmap": [
     { "title": "Fix remaining vulnerabilities", "state": "in_progress" },
-    { "title": "Relaunch Genesis", "state": "up_next" },
-    { "title": "Launch Horizon", "state": "planned" },
+    { "title": "Stabilize Horizon environment", "state": "up_next" },
+    { "title": "Open Adiri public testnet", "state": "planned" },
     { "title": "Final audits & competition", "state": "planned" },
-    { "title": "Zenith launch", "state": "planned" }
+    { "title": "Mainnet launch", "state": "planned" }
   ],
   "links": {
     "governanceForum": "https://forum.telcoin.org/",


### PR DESCRIPTION
## Summary
- retune the hero header copy to highlight the Horizon, Adiri, and Mainnet phases with smaller typography
- animate the overall trajectory progress bar and in-progress badge while updating the phase cards to the new names and summaries
- rewrite the Learn more accordion with updated Horizon/Adiri/Mainnet explanations and add external resource buttons for Telcoin Association and TAO Twitter

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d84221e32c8324876db46f11607cea