### PR TITLE
Update roadmap copy and progress indicators

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,7 +90,7 @@ export default function App() {
                   <p className="max-w-xl text-sm text-fg-muted md:text-base">{headerDescription}</p>
                 </div>
                 <div className="w-full max-w-sm rounded-3xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
-                  <ProgressBar value={status.meta.overallTrajectoryPct} label="Overall trajectory" />
+                  <ProgressBar value={status.meta.overallTrajectoryPct} label="Road to Mainnet" />
                   <p className="mt-4 text-sm text-fg-muted">
                     Last updated <time dateTime={status.meta.lastUpdated}>{formattedLastUpdated}</time>
                   </p>

--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "meta": { "lastUpdated": "2025-09-23T19:00:00Z", "overallTrajectoryPct": 25 },
+  "meta": { "lastUpdated": "2025-09-23T19:00:00Z", "overallTrajectoryPct": 60 },
   "phases": [
     {
       "key": "devnet",
@@ -11,7 +11,7 @@
       "key": "testnet",
       "title": "Adiri",
       "status": "upcoming",
-      "summary": "Preparing the Adiri public testnet so partners and community validators can exercise the network in a live setting."
+      "summary": "Preparing the Adiri public testnet so partners and MNO validators can exercise the network in a live setting."
     },
     {
       "key": "mainnet",


### PR DESCRIPTION
## Summary
- rename the hero progress widget to "Road to Mainnet"
- bump the roadmap progress value to 60% in the status data
- adjust the Adiri phase summary to reference MNO validators

## Testing
- npm run lint *(fails: existing lint errors in src/security/PasswordGate.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d867bfe77083248c8fc0bc3b31971a