### PR TITLE
feat: update phase logos for horizon and adiri

### DIFF
--- a/src/assets/adiri.svg
+++ b/src/assets/adiri.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="adiriGradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#4c78ff" />
+      <stop offset="1" stop-color="#1ad4ff" />
+    </linearGradient>
+    <linearGradient id="adiriStroke" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#4c78ff" />
+      <stop offset="1" stop-color="#1ad4ff" />
+    </linearGradient>
+  </defs>
+  <circle cx="256" cy="256" r="232" fill="none" stroke="url(#adiriStroke)" stroke-width="32" />
+  <path
+    d="M256 88L72 416h108l50-96h52l50 96h108L256 88z"
+    fill="url(#adiriGradient)"
+  />
+  <path
+    d="M256 198l54 104h-108l54-104z"
+    fill="#f2fbff"
+    opacity="0.8"
+  />
+</svg>

--- a/src/assets/horizon.svg
+++ b/src/assets/horizon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="horizonGradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#4c78ff" />
+      <stop offset="1" stop-color="#1ad4ff" />
+    </linearGradient>
+    <linearGradient id="horizonStroke" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#4c78ff" />
+      <stop offset="1" stop-color="#1ad4ff" />
+    </linearGradient>
+  </defs>
+  <circle cx="256" cy="256" r="232" fill="none" stroke="url(#horizonStroke)" stroke-width="32" />
+  <path
+    d="M160 120h-64v272h64v-96h192v96h64V120h-64v120H160V120z"
+    fill="url(#horizonGradient)"
+  />
+</svg>

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -1,6 +1,8 @@
 import { motion, useReducedMotion } from 'framer-motion';
 import type { Phase } from '../data/statusSchema';
 import { CompassIcon, LaunchIcon, MainnetIcon, NetworkIcon, TestnetIcon } from './icons';
+import adiriLogo from '../assets/adiri.svg';
+import horizonLogo from '../assets/horizon.svg';
 import { formatList } from '../utils/formatList';
 
 const STATUS_LABELS: Record<Phase['status'], { text: string; className: string; ariaLabel: string; shouldPulse?: boolean }> = {
@@ -26,6 +28,13 @@ const PHASE_ICONS: Partial<Record<Phase['key'], typeof NetworkIcon>> = {
   devnet: LaunchIcon,
   testnet: TestnetIcon,
   mainnet: MainnetIcon
+};
+
+const PHASE_LOGOS: Partial<
+  Record<Phase['key'], { alt: string; src: string }>
+> = {
+  devnet: { src: horizonLogo, alt: 'Horizon phase logo' },
+  testnet: { src: adiriLogo, alt: 'Adiri phase logo' }
 };
 
 const PHASE_CODE_NAMES: Record<Phase['key'], string> = {
@@ -63,6 +72,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
         {phases.map((phase) => {
           const badge = STATUS_LABELS[phase.status];
           const Icon = PHASE_ICONS[phase.key] ?? NetworkIcon;
+          const logo = PHASE_LOGOS[phase.key];
           return (
             <motion.article
               key={phase.key}
@@ -72,7 +82,15 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
               <header className="flex items-start justify-between gap-4">
                 <div className="flex items-center gap-3">
                   <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                    <Icon className="h-6 w-6" />
+                    {logo ? (
+                      <img
+                        alt={logo.alt}
+                        className="h-9 w-9"
+                        src={logo.src}
+                      />
+                    ) : (
+                      <Icon className="h-6 w-6" />
+                    )}
                   </div>
                   <div>
                     <h3 className="text-lg font-semibold text-fg">{phase.title}</h3>


### PR DESCRIPTION
## Summary
- add dedicated Horizon and Adiri logo assets
- display the new logos in the Phase overview cards while keeping the existing fallback icons

## Testing
- npm run build:nogate

------
https://chatgpt.com/codex/tasks/task_e_68da9a84f1e08330a5416dce78d0fa3c