### PR TITLE
feat: use provided Horizon and Adiri logos

### DIFF
--- a/src/assets/Adiri logo.svg
+++ b/src/assets/Adiri logo.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 254.29 248">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #4066de;
+      }
+
+      .cls-2 {
+        fill: #fff;
+      }
+
+      .cls-3 {
+        clip-rule: evenodd;
+        fill: none;
+      }
+
+      .cls-4 {
+        fill: url(#linear-gradient);
+      }
+
+      .cls-5 {
+        clip-path: url(#clippath);
+      }
+    </style>
+    <clipPath id="clippath">
+      <path class="cls-3" d="M171.46,185.36l-11.89-20.73c-1.27-2.21-3.44-3.46-5.98-3.46l-85.28.25c-1.28,0-2.38-.63-3.01-1.74-.64-1.11-.63-2.38,0-3.49l14.02-24.28,55.36-.15c1.28,0,2.37-.65,3.02-1.76.65-1.11.65-2.38.01-3.49l-12.87-22.45c-.64-1.11-1.73-1.74-3.01-1.74l-19.44.05c-1.27,0-2.37-.62-3-1.73-.64-1.11-.63-2.38.01-3.49l24.8-42.95c.64-1.11,1.74-1.75,3.02-1.75,1.28,0,2.37.63,3,1.73,25.05,43.69,50.11,87.37,75.17,131.06.64,1.11,1.73,1.74,3,1.73,1.28,0,2.37-.64,3.01-1.75l12.01-20.79c1.28-2.21,1.29-4.74.02-6.94L146.25,22.92c-1.27-2.2-3.45-3.46-5.99-3.46l-25.93.08c-2.54,0-4.73,1.27-6,3.49l-43.87,75.99c-1.28,2.21-1.28,4.73-.02,6.94l14.88,25.95-29.92.09c-2.54,0-4.72,1.28-6,3.49l-13.02,22.56c-1.28,2.22-1.29,4.74-.02,6.94l12.9,22.5c1.27,2.21,3.45,3.47,5.98,3.46l119.19-.35c1.27,0,2.37-.65,3.01-1.75s.65-2.39.01-3.49"/>
+    </clipPath>
+    <linearGradient id="linear-gradient" x1="230.94" y1="171.76" x2="82.92" y2="137.42" gradientTransform="translate(-18.71 293.89) rotate(-90) scale(1.04)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#4066de"/>
+      <stop offset=".2" stop-color="#3e68de"/>
+      <stop offset=".34" stop-color="#3a72e2"/>
+      <stop offset=".47" stop-color="#3382e7"/>
+      <stop offset=".59" stop-color="#2a98ef"/>
+      <stop offset=".69" stop-color="#1db5f8"/>
+      <stop offset=".75" stop-color="#16c8ff"/>
+    </linearGradient>
+  </defs>
+  <g id="Layer_1-2" data-name="Layer 1">
+    <ellipse class="cls-1" cx="127.14" cy="124" rx="127.14" ry="124"/>
+    <ellipse class="cls-2" cx="127.24" cy="124" rx="114.57" ry="112.57"/>
+    <g class="cls-5">
+      <rect class="cls-4" x="44.83" y="47.95" width="196.58" height="170.36" transform="translate(-43.74 190.51) rotate(-60)"/>
+    </g>
+  </g>
+</svg>

--- a/src/assets/Horizon logo.svg
+++ b/src/assets/Horizon logo.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 254.29 248">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #4066de;
+      }
+
+      .cls-2 {
+        fill: #fff;
+      }
+
+      .cls-3 {
+        fill: url(#linear-gradient-2);
+      }
+
+      .cls-3, .cls-4 {
+        fill-rule: evenodd;
+      }
+
+      .cls-4 {
+        fill: url(#linear-gradient);
+      }
+    </style>
+    <linearGradient id="linear-gradient" x1="56.68" y1="149.16" x2="198.26" y2="149.16" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#45bcf1"/>
+      <stop offset=".15" stop-color="#44abed"/>
+      <stop offset=".52" stop-color="#4185e5"/>
+      <stop offset=".81" stop-color="#406edf"/>
+      <stop offset="1" stop-color="#4066de"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="56.68" y1="98.62" x2="198.26" y2="98.62" xlink:href="#linear-gradient"/>
+  </defs>
+  <g id="Layer_1-2" data-name="Layer 1">
+    <ellipse class="cls-1" cx="127.14" cy="124" rx="127.14" ry="124"/>
+    <ellipse class="cls-2" cx="127.24" cy="124" rx="114.57" ry="112.57"/>
+    <path class="cls-4" d="M170.66,129.13h-86.38c0,25.58,0,51.16,0,76.74l43.19,18.96,70.79-31.07v-85.6s-13.78,0-13.78,0c0,26.55-.04,53.03-.04,79.59-21.48,9.43-35.61,15.63-56.97,25l-29.37-12.89c0-20.08,0-40.15,0-60.23h58.74s0,48.08,0,48.08l13.82-6.06v-52.52ZM170.66,118.66h-86.38s0-10.5,0-10.5h86.38s0,10.5,0,10.5ZM70.46,73.49h-13.78s0,111.04,0,111.04l13.78,7.85c0-39.64,0-79.23,0-118.88Z"/>
+    <path class="cls-3" d="M84.28,118.65h86.38V41.91l-43.19-18.96-70.79,31.07v85.6h13.78c0-26.55.04-53.03.04-79.59,21.48-9.43,35.61-15.63,56.97-25l29.37,12.89v60.23h-58.74v-48.08l-13.82,6.06v52.52ZM84.28,129.12h86.38v10.5h-86.38v-10.5ZM184.48,174.29h13.78s0-111.04,0-111.04l-13.78-7.85c0,39.64,0,79.23,0,118.88Z"/>
+  </g>
+</svg>

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -1,6 +1,8 @@
 import { motion, useReducedMotion } from 'framer-motion';
 import type { Phase } from '../data/statusSchema';
 import { CompassIcon, LaunchIcon, MainnetIcon, NetworkIcon, TestnetIcon } from './icons';
+import adiriLogo from '../assets/Adiri logo.svg';
+import horizonLogo from '../assets/Horizon logo.svg';
 import { formatList } from '../utils/formatList';
 
 const STATUS_LABELS: Record<Phase['status'], { text: string; className: string; ariaLabel: string; shouldPulse?: boolean }> = {
@@ -26,6 +28,13 @@ const PHASE_ICONS: Partial<Record<Phase['key'], typeof NetworkIcon>> = {
   devnet: LaunchIcon,
   testnet: TestnetIcon,
   mainnet: MainnetIcon
+};
+
+const PHASE_LOGOS: Partial<
+  Record<Phase['key'], { alt: string; src: string }>
+> = {
+  devnet: { src: horizonLogo, alt: 'Horizon phase logo' },
+  testnet: { src: adiriLogo, alt: 'Adiri phase logo' }
 };
 
 const PHASE_CODE_NAMES: Record<Phase['key'], string> = {
@@ -63,6 +72,9 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
         {phases.map((phase) => {
           const badge = STATUS_LABELS[phase.status];
           const Icon = PHASE_ICONS[phase.key] ?? NetworkIcon;
+          const logo = PHASE_LOGOS[phase.key];
+          const hasLogo = Boolean(logo);
+
           return (
             <motion.article
               key={phase.key}
@@ -71,8 +83,20 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
             >
               <header className="flex items-start justify-between gap-4">
                 <div className="flex items-center gap-3">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-                    <Icon className="h-6 w-6" />
+                  <div
+                    className={`flex h-12 w-12 items-center justify-center rounded-2xl ${
+                      hasLogo ? '' : 'bg-primary/10 text-primary'
+                    }`}
+                  >
+                    {hasLogo && logo ? (
+                      <img
+                        alt={logo.alt}
+                        className="h-10 w-10 object-contain"
+                        src={logo.src}
+                      />
+                    ) : (
+                      <Icon className="h-6 w-6" />
+                    )}
                   </div>
                   <div>
                     <h3 className="text-lg font-semibold text-fg">{phase.title}</h3>


### PR DESCRIPTION
## Summary
- replace the Horizon and Adiri assets with the provided SVG logo files
- update the phase overview to render the new SVG logos while keeping icon fallbacks untouched

## Testing
- npm run typecheck
- npm run build:nogate

------
https://chatgpt.com/codex/tasks/task_e_68da9a84f1e08330a5416dce78d0fa3c