### PR TITLE
Use official Adiri SVG asset for phase icon

### DIFF
--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -1,6 +1,6 @@
 import { motion, useReducedMotion } from 'framer-motion';
 import type { Phase } from '../data/statusSchema';
-import { CompassIcon, LaunchIcon, MainnetIcon, NetworkIcon, TestnetIcon } from './icons';
+import { AdiriLogoIcon, CompassIcon, HorizonLogoIcon, MainnetIcon, NetworkIcon } from './icons';
 import { formatList } from '../utils/formatList';
 
 const STATUS_LABELS: Record<Phase['status'], { text: string; className: string; ariaLabel: string; shouldPulse?: boolean }> = {
@@ -23,8 +23,8 @@ const STATUS_LABELS: Record<Phase['status'], { text: string; className: string; 
 };
 
 const PHASE_ICONS: Partial<Record<Phase['key'], typeof NetworkIcon>> = {
-  devnet: LaunchIcon,
-  testnet: TestnetIcon,
+  devnet: HorizonLogoIcon,
+  testnet: AdiriLogoIcon,
   mainnet: MainnetIcon
 };
 

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,5 +1,8 @@
 import type { SVGProps } from 'react';
 
+import AdiriLogoSvg from '../../IMG/Adiri logo.svg?react';
+import HorizonLogoSvg from '../../IMG/Horizon logo.svg?react';
+
 type IconProps = SVGProps<SVGSVGElement>;
 
 const baseClasses = 'h-6 w-6 text-primary';
@@ -43,6 +46,26 @@ export function LaunchIcon({ className, ...props }: IconProps) {
       />
       <path strokeLinecap="round" strokeLinejoin="round" d="M12 9l3 3" />
     </svg>
+  );
+}
+
+export function AdiriLogoIcon({ className, ...props }: IconProps) {
+  return (
+    <AdiriLogoSvg
+      aria-hidden="true"
+      className={`${baseClasses} ${className ?? ''}`}
+      {...props}
+    />
+  );
+}
+
+export function HorizonLogoIcon({ className, ...props }: IconProps) {
+  return (
+    <HorizonLogoSvg
+      aria-hidden="true"
+      className={`${baseClasses} ${className ?? ''}`}
+      {...props}
+    />
   );
 }
 

--- a/src/types/vite-plugin-svgr.d.ts
+++ b/src/types/vite-plugin-svgr.d.ts
@@ -1,0 +1,7 @@
+declare module 'vite-plugin-svgr';
+
+declare module '*.svg?react' {
+  import type { FC, SVGProps } from 'react';
+  const ReactComponent: FC<SVGProps<SVGSVGElement>>;
+  export default ReactComponent;
+}


### PR DESCRIPTION
## Summary
- import the Adiri SVG asset directly so the phase icon renders the official logo
- simplify the AdiriLogoIcon component by delegating to the shared SVG React component

## Testing
- npm run typecheck
- npm run build:nogate

------
https://chatgpt.com/codex/tasks/task_e_68daab6a2ea88330b42fb815e6977c9a