### PR TITLE
feat: replace Horizon and Adiri phase logos

### DIFF
--- a/src/assets/adiri.svg
+++ b/src/assets/adiri.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 254.29 248">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #4066de;
+      }
+
+      .cls-2 {
+        clip-rule: evenodd;
+        fill: none;
+      }
+
+      .cls-3 {
+        fill: url(#linear-gradient);
+      }
+
+      .cls-4 {
+        clip-path: url(#clippath);
+      }
+    </style>
+    <clipPath id="clippath">
+      <path class="cls-2" d="M171.46,185.36l-11.89-20.73c-1.27-2.21-3.44-3.46-5.98-3.46l-85.28.25c-1.28,0-2.38-.63-3.01-1.74-.64-1.11-.63-2.38,0-3.49l14.02-24.28,55.36-.15c1.28,0,2.37-.65,3.02-1.76.65-1.11.65-2.38.01-3.49l-12.87-22.45c-.64-1.11-1.73-1.74-3.01-1.74l-19.44.05c-1.27,0-2.37-.62-3-1.73-.64-1.11-.63-2.38.01-3.49l24.8-42.95c.64-1.11,1.74-1.75,3.02-1.75,1.28,0,2.37.63,3,1.73,25.05,43.69,50.11,87.37,75.17,131.06.64,1.11,1.73,1.74,3,1.73,1.28,0,2.37-.64,3.01-1.75l12.01-20.79c1.28-2.21,1.29-4.74.02-6.94L146.25,22.92c-1.27-2.2-3.45-3.46-5.99-3.46l-25.93.08c-2.54,0-4.73,1.27-6,3.49l-43.87,75.99c-1.28,2.21-1.28,4.73-.02,6.94l14.88,25.95-29.92.09c-2.54,0-4.72,1.28-6,3.49l-13.02,22.56c-1.28,2.22-1.29,4.74-.02,6.94l12.9,22.5c1.27,2.21,3.45,3.47,5.98,3.46l119.19-.35c1.27,0,2.37-.65,3.01-1.75s.65-2.39.01-3.49"/>
+    </clipPath>
+    <linearGradient id="linear-gradient" x1="230.94" y1="171.76" x2="82.92" y2="137.42" gradientTransform="translate(-18.71 293.89) rotate(-90) scale(1.04)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#4066de"/>
+      <stop offset=".2" stop-color="#3e68de"/>
+      <stop offset=".34" stop-color="#3a72e2"/>
+      <stop offset=".47" stop-color="#3382e7"/>
+      <stop offset=".59" stop-color="#2a98ef"/>
+      <stop offset=".69" stop-color="#1db5f8"/>
+      <stop offset=".75" stop-color="#16c8ff"/>
+    </linearGradient>
+  </defs>
+  <g id="Layer_1-2" data-name="Layer 1">
+    <path class="cls-1" d="M127.14,0C56.92,0,0,55.52,0,124s56.92,124,127.14,124,127.14-55.52,127.14-124S197.36,0,127.14,0ZM127.24,236.57c-63.28,0-114.57-50.4-114.57-112.57S63.96,11.43,127.24,11.43s114.57,50.4,114.57,112.57-51.3,112.57-114.57,112.57Z"/>
+    <g class="cls-4">
+      <rect class="cls-3" x="44.83" y="47.95" width="196.58" height="170.36" transform="translate(-43.74 190.51) rotate(-60)"/>
+    </g>
+  </g>
+</svg>

--- a/src/assets/horizon.svg
+++ b/src/assets/horizon.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 254.29 248">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #4066de;
+      }
+
+      .cls-2 {
+        fill: url(#linear-gradient-2);
+      }
+
+      .cls-2, .cls-3 {
+        fill-rule: evenodd;
+      }
+
+      .cls-3 {
+        fill: url(#linear-gradient);
+      }
+    </style>
+    <linearGradient id="linear-gradient" x1="56.68" y1="149.16" x2="198.26" y2="149.16" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#45bcf1"/>
+      <stop offset=".15" stop-color="#44abed"/>
+      <stop offset=".52" stop-color="#4185e5"/>
+      <stop offset=".81" stop-color="#406edf"/>
+      <stop offset="1" stop-color="#4066de"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="56.68" y1="98.62" x2="198.26" y2="98.62" xlink:href="#linear-gradient"/>
+  </defs>
+  <g id="Layer_1-2" data-name="Layer 1">
+    <path class="cls-1" d="M127.14,0C56.92,0,0,55.52,0,124s56.92,124,127.14,124,127.14-55.52,127.14-124S197.36,0,127.14,0ZM127.24,236.57c-63.28,0-114.57-50.4-114.57-112.57S63.96,11.43,127.24,11.43s114.57,50.4,114.57,112.57-51.3,112.57-114.57,112.57Z"/>
+    <path class="cls-3" d="M170.66,129.13h-86.38c0,25.58,0,51.16,0,76.74l43.19,18.96,70.79-31.07v-85.6s-13.78,0-13.78,0c0,26.55-.04,53.03-.04,79.59-21.48,9.43-35.61,15.63-56.97,25l-29.37-12.89c0-20.08,0-40.15,0-60.23h58.74s0,48.08,0,48.08l13.82-6.06v-52.52ZM170.66,118.66h-86.38s0-10.5,0-10.5h86.38s0,10.5,0,10.5ZM70.46,73.49h-13.78s0,111.04,0,111.04l13.78,7.85c0-39.64,0-79.23,0-118.88Z"/>
+    <path class="cls-2" d="M84.28,118.65h86.38V41.91l-43.19-18.96-70.79,31.07v85.6h13.78c0-26.55.04-53.03.04-79.59,21.48-9.43,35.61-15.63,56.97-25l29.37,12.89v60.23h-58.74v-48.08l-13.82,6.06v52.52ZM84.28,129.12h86.38v10.5h-86.38v-10.5ZM184.48,174.29h13.78s0-111.04,0-111.04l-13.78-7.85c0,39.64,0,79.23,0,118.88Z"/>
+  </g>
+</svg>

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -1,15 +1,15 @@
 import { motion, useReducedMotion } from 'framer-motion';
+
+import HorizonLogoUrl from '@/assets/horizon.svg?url';
+import AdiriLogoUrl from '@/assets/adiri.svg?url';
 import type { Phase } from '../data/statusSchema';
-codex/replace-phase-overview-logo-with-adiri.svg
-import { AdiriLogoIcon, CompassIcon, HorizonLogoIcon, MainnetIcon, NetworkIcon } from './icons';
-=======
-import { CompassIcon, LaunchIcon, MainnetIcon, NetworkIcon, TestnetIcon } from './icons';
-import adiriLogo from '../assets/Adiri logo.svg';
-import horizonLogo from '../assets/Horizon logo.svg';
- main
+import { CompassIcon, MainnetIcon, NetworkIcon } from './icons';
 import { formatList } from '../utils/formatList';
 
-const STATUS_LABELS: Record<Phase['status'], { text: string; className: string; ariaLabel: string; shouldPulse?: boolean }> = {
+const STATUS_LABELS: Record<
+  Phase['status'],
+  { text: string; className: string; ariaLabel: string; shouldPulse?: boolean }
+> = {
   in_progress: {
     text: 'In progress',
     className: 'border-primary/50 bg-primary/20 text-primary',
@@ -29,16 +29,12 @@ const STATUS_LABELS: Record<Phase['status'], { text: string; className: string; 
 };
 
 const PHASE_ICONS: Partial<Record<Phase['key'], typeof NetworkIcon>> = {
-  devnet: HorizonLogoIcon,
-  testnet: AdiriLogoIcon,
   mainnet: MainnetIcon
 };
 
-const PHASE_LOGOS: Partial<
-  Record<Phase['key'], { alt: string; src: string }>
-> = {
-  devnet: { src: horizonLogo, alt: 'Horizon phase logo' },
-  testnet: { src: adiriLogo, alt: 'Adiri phase logo' }
+const PHASE_LOGOS: Partial<Record<Phase['key'], { src: string; alt: string }>> = {
+  devnet: { src: HorizonLogoUrl, alt: 'Horizon logo' },
+  testnet: { src: AdiriLogoUrl, alt: 'Adiri logo' }
 };
 
 const PHASE_CODE_NAMES: Record<Phase['key'], string> = {
@@ -77,7 +73,6 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
           const badge = STATUS_LABELS[phase.status];
           const Icon = PHASE_ICONS[phase.key] ?? NetworkIcon;
           const logo = PHASE_LOGOS[phase.key];
-          const hasLogo = Boolean(logo);
 
           return (
             <motion.article
@@ -87,19 +82,17 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
             >
               <header className="flex items-start justify-between gap-4">
                 <div className="flex items-center gap-3">
-                  <div
-                    className={`flex h-12 w-12 items-center justify-center rounded-2xl ${
-                      hasLogo ? '' : 'bg-primary/10 text-primary'
-                    }`}
-                  >
-                    {hasLogo && logo ? (
+                  <div className="flex h-9 w-9 items-center justify-center rounded-2xl bg-primary/10 text-primary md:h-10 md:w-10">
+                    {logo ? (
                       <img
-                        alt={logo.alt}
-                        className="h-10 w-10 object-contain"
                         src={logo.src}
+                        alt={logo.alt}
+                        className="h-9 w-9 shrink-0 object-contain md:h-10 md:w-10"
+                        loading="eager"
+                        decoding="async"
                       />
                     ) : (
-                      <Icon className="h-6 w-6" />
+                      <Icon className="h-5 w-5 md:h-6 md:w-6" />
                     )}
                   </div>
                   <div>
@@ -113,9 +106,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
                   aria-label={badge.ariaLabel}
                   className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${badge.className}`}
                   role="status"
-                  animate={
-                    !reduceMotion && badge.shouldPulse ? { opacity: [1, 0.5, 1] } : undefined
-                  }
+                  animate={!reduceMotion && badge.shouldPulse ? { opacity: [1, 0.5, 1] } : undefined}
                   transition={
                     !reduceMotion && badge.shouldPulse
                       ? { duration: 1.2, repeat: Infinity, repeatType: 'reverse', ease: 'easeInOut' }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vitest/globals", "vite/client", "node"]
+    "types": ["vitest/globals", "vite/client", "node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src", "scripts", "vite.config.ts", "tailwind.config.ts", "postcss.config.js"],
   "exclude": ["dist", "node_modules"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,5 +18,10 @@ const base = hasCustomDomain ? '/' : defaultBase;
 
 export default defineConfig(({ command }) => ({
   base: command === 'serve' ? '/' : base,
-  plugins: [react(), svgr()]
+  plugins: [react(), svgr()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  }
 }));


### PR DESCRIPTION
## Summary
- swap the Horizon and Adiri phase overview cards to use the official SVG logo assets
- add canonical SVG copies under `src/assets/` for clean imports and configure the shared `@/` alias
- keep Mainnet on the existing icon while tightening the phase header image handling for consistent sizing

## Testing
- `npm run typecheck`
- `npm run build:nogate`

<details>
<summary>npm run typecheck (tail)</summary>

```sh
> tn-roadmap@0.1.0 typecheck
> tsc --noEmit
```

</details>

<details>
<summary>npm run build:nogate (tail)</summary>

```sh
✓ 444 modules transformed.
dist/index.html                   0.58 kB │ gzip:   0.34 kB
dist/assets/index-BSvhWs0-.css   21.60 kB │ gzip:   5.07 kB
dist/assets/index-Bzno0wh_.js   345.43 kB │ gzip: 107.84 kB
✓ built in 6.89s
```

</details>

## Screenshots (build:nogate)
![Phase overview – 375px viewport](browser:/invocations/qekwekli/artifacts/artifacts/phase-overview-375.png)
![Phase overview – 768px viewport](browser:/invocations/qekwekli/artifacts/artifacts/phase-overview-768.png)
![Phase overview – 1280px viewport](browser:/invocations/qekwekli/artifacts/artifacts/phase-overview-1280.png)


------
https://chatgpt.com/codex/tasks/task_e_68dabfc627208330bd4a67b25fd200cd