### PR TITLE
feat: update phase subtitles and learn more logos

### DIFF
--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
+import HorizonLogoUrl from '@/assets/horizon.svg?url';
+import AdiriLogoUrl from '@/assets/adiri.svg?url';
 import type { Phase, Status } from '../data/statusSchema';
 import { ChevronIcon, ExternalLinkIcon, InfoIcon } from './icons';
 
@@ -80,6 +82,10 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
       <div className="space-y-4">
         {sections.map((section) => {
           const isOpen = openId === section.id;
+          const t = section.title?.trim().toLowerCase();
+          const isHorizon = t === 'what is horizon';
+          const isAdiri = t === 'what is adiri';
+          const rowLogo = isHorizon ? HorizonLogoUrl : isAdiri ? AdiriLogoUrl : undefined;
           return (
             <article
               key={section.id}
@@ -95,9 +101,19 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
                 whileTap={{ scale: 0.99 }}
               >
                 <span className="flex items-center gap-3 text-base font-semibold text-fg">
-                  <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/20 text-primary">
-                    <InfoIcon className="h-5 w-5" />
-                  </span>
+                  <div className="flex h-9 w-9 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                    {rowLogo ? (
+                      <img
+                        src={rowLogo}
+                        alt={isHorizon ? 'Horizon logo' : 'Adiri logo'}
+                        className="h-7 w-7 shrink-0 object-contain md:h-8 md:w-8"
+                        loading="eager"
+                        decoding="async"
+                      />
+                    ) : (
+                      <InfoIcon className="h-5 w-5 md:h-6 md:w-6" />
+                    )}
+                  </div>
                   {section.title}
                 </span>
                 <span aria-hidden="true" className={`transition-transform ${isOpen ? 'rotate-90' : ''}`}>

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -37,12 +37,6 @@ const PHASE_LOGOS: Partial<Record<Phase['key'], { src: string; alt: string }>> =
   testnet: { src: AdiriLogoUrl, alt: 'Adiri logo' }
 };
 
-const PHASE_CODE_NAMES: Record<Phase['key'], string> = {
-  devnet: 'Horizon',
-  testnet: 'Adiri',
-  mainnet: 'Mainnet'
-};
-
 type PhaseOverviewProps = {
   phases: Phase[];
 };
@@ -74,6 +68,8 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
           const Icon = PHASE_ICONS[phase.key] ?? NetworkIcon;
           const logo = PHASE_LOGOS[phase.key];
 
+          const subtitle = 'Release';
+
           return (
             <motion.article
               key={phase.key}
@@ -97,8 +93,11 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
                   </div>
                   <div>
                     <h3 className="text-lg font-semibold text-fg">{phase.title}</h3>
-                    <p className="text-xs uppercase tracking-[0.2em] text-fg-muted/70">
-                      {PHASE_CODE_NAMES[phase.key]}
+                    <p
+                      className="text-xs uppercase tracking-[0.2em] text-fg-muted/70"
+                      data-phase-subtitle="release"
+                    >
+                      {subtitle}
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- show a consistent "Release" subtitle across Horizon, Adiri, and Mainnet phase tiles
- swap the Horizon and Adiri learn-more rows to use their official logos while preserving other icons

## Screenshots
![Phase overview at 375px](browser:/invocations/xzhfducv/artifacts/artifacts/phase-overview-375.png)
![Phase overview at 768px](browser:/invocations/vzeymuon/artifacts/artifacts/phase-overview-768.png)
![Phase overview at 1280px](browser:/invocations/pjudbnbc/artifacts/artifacts/phase-overview-1280.png)

## Testing
- npm run typecheck
- npm run build:nogate

<details>
<summary>npm run typecheck (tail)</summary>

```
> tn-roadmap@0.1.0 typecheck
> tsc --noEmit
```

</details>

<details>
<summary>npm run build:nogate (tail)</summary>

```
dist/index.html                   0.58 kB │ gzip:   0.34 kB
dist/assets/index-HQNsO6bz.css   21.64 kB │ gzip:   5.08 kB
dist/assets/index-oQ1qohiJ.js   345.66 kB │ gzip: 107.88 kB
✓ built in 5.17s
```

</details>


------
https://chatgpt.com/codex/tasks/task_e_68dacd413f44833098453db17f9bc956