### PR TITLE
Update Mainnet logo references to new SVG

### DIFF
--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -3,7 +3,7 @@ import { motion, useReducedMotion } from 'framer-motion';
 import HorizonLogoUrl from '@/assets/horizon.svg?url';
 import AdiriLogoUrl from '@/assets/adiri.svg?url';
 import type { Phase } from '../data/statusSchema';
-import { CompassIcon, MainnetIcon, NetworkIcon } from './icons';
+import { CompassIcon, NetworkIcon } from './icons';
 import { formatList } from '../utils/formatList';
 
 const STATUS_LABELS: Record<
@@ -28,13 +28,10 @@ const STATUS_LABELS: Record<
   }
 };
 
-const PHASE_ICONS: Partial<Record<Phase['key'], typeof NetworkIcon>> = {
-  mainnet: MainnetIcon
-};
-
 const PHASE_LOGOS: Partial<Record<Phase['key'], { src: string; alt: string }>> = {
   devnet: { src: HorizonLogoUrl, alt: 'Horizon logo' },
-  testnet: { src: AdiriLogoUrl, alt: 'Adiri logo' }
+  testnet: { src: AdiriLogoUrl, alt: 'Adiri logo' },
+  mainnet: { src: '/IMG/Mainnet.svg', alt: 'Mainnet Logo' }
 };
 
 type PhaseOverviewProps = {
@@ -65,7 +62,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
       <div className="grid gap-6 md:grid-cols-3">
         {phases.map((phase) => {
           const badge = STATUS_LABELS[phase.status];
-          const Icon = PHASE_ICONS[phase.key] ?? NetworkIcon;
+          const Icon = NetworkIcon;
           const logo = PHASE_LOGOS[phase.key];
 
           const subtitle = 'Release';
@@ -83,7 +80,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
                       <img
                         src={logo.src}
                         alt={logo.alt}
-                        className="h-9 w-9 shrink-0 object-contain md:h-10 md:w-10"
+                        className="h-auto w-full max-h-9 max-w-9 shrink-0 object-contain md:max-h-10 md:max-w-10"
                         loading="eager"
                         decoding="async"
                       />

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,9 +1,10 @@
-import type { SVGProps } from 'react';
+import type { ComponentPropsWithoutRef, SVGProps } from 'react';
 import { useId } from 'react';
 
 import HorizonLogoSvg from '../../IMG/Horizon logo.svg?react';
 
 type IconProps = SVGProps<SVGSVGElement>;
+type ImageIconProps = ComponentPropsWithoutRef<'img'>;
 
 const baseClasses = 'h-6 w-6 text-primary';
 
@@ -138,24 +139,14 @@ export function TestnetIcon({ className, ...props }: IconProps) {
   );
 }
 
-export function MainnetIcon({ className, ...props }: IconProps) {
+export function MainnetIcon({ className, alt = 'Mainnet Logo', ...props }: ImageIconProps) {
   return (
-    <svg
-      aria-hidden="true"
-      className={`${baseClasses} ${className ?? ''}`}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={1.5}
+    <img
+      src="/IMG/Mainnet.svg"
+      alt={alt}
+      className={`h-auto w-full ${className ?? ''}`}
       {...props}
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M12 3l6.928 4v8L12 19l-6.928-4V7z"
-      />
-      <path strokeLinecap="round" strokeLinejoin="round" d="M12 7l4 2.309v4.382L12 16l-4-2.309V9.309z" />
-    </svg>
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
- replace the Mainnet icon component so it serves the shared /IMG/Mainnet.svg asset
- show the Mainnet logo image in the phase overview card using the new SVG with responsive sizing

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dadf4bf2788330b3e46511e1afd467