### PR TITLE
feat(ui): make Phase overview cards anchor + auto-expand Learn more; update What is Mainnet copy

### DIFF
--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -31,8 +31,8 @@ const LEARN_MORE_CONTENT: Record<Phase['key'], { title: string; body: string[] }
   mainnet: {
     title: 'What is Mainnet',
     body: [
-      'Mainnet is the name for the Telcoin Network’s mainnet launch—the culmination of the Horizon and Adiri phases. Once Adiri has achieved stability and passed the final rounds of audits and the open security competition, the network will transition to Mainnet.',
-      'Mainnet represents the full public launch of the Telcoin Network, where validators, developers, and users can rely on the system for real value transfer and application deployment. It’s the point at which the network moves from testing to production, with the security and decentralization guarantees expected of a Layer 1 blockchain.'
+      'Mainnet is the Telcoin Network’s full launch, following the Horizon and Adiri phases. It marks the transition from testing to production, where validators, developers, and users can rely on the system for real value transfer and application deployment.',
+      'Mainnet will roll out in two stages—Alpha Mainnet and Beta Mainnet—but both are part of the same Mainnet launch. Alpha focuses on initial deployment and stability under real conditions, while Beta expands participation and prepares the network for full-scale operation. Together, these phases deliver the security and decentralization guarantees expected of a Layer 1 blockchain.'
     ]
   }
 };
@@ -44,8 +44,40 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
     return activePhase?.key ?? orderedSections[0]?.key ?? null;
   }, [orderedSections]);
   const [openId, setOpenId] = useState<Phase['key'] | null>(defaultOpenId);
+
   useEffect(() => {
-    setOpenId(defaultOpenId);
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const hashToPhaseKey: Record<string, Phase['key']> = {
+      'what-is-horizon': 'devnet',
+      'what-is-adiri': 'testnet',
+      'what-is-mainnet': 'mainnet'
+    };
+
+    const applyHash = () => {
+      const hash = window.location.hash.replace('#', '');
+      const matchedPhase = hashToPhaseKey[hash];
+
+      if (matchedPhase) {
+        setOpenId(matchedPhase);
+
+        const element = document.getElementById(hash);
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      } else {
+        setOpenId(defaultOpenId);
+      }
+    };
+
+    applyHash();
+    window.addEventListener('hashchange', applyHash);
+
+    return () => {
+      window.removeEventListener('hashchange', applyHash);
+    };
   }, [defaultOpenId]);
 
   const sections = orderedSections.map((section) => ({
@@ -103,7 +135,15 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
           return (
             <article
               key={section.id}
-              id={`learn-more-${section.id}`}
+              id={
+                isHorizon
+                  ? 'what-is-horizon'
+                  : isAdiri
+                    ? 'what-is-adiri'
+                    : isMainnet
+                      ? 'what-is-mainnet'
+                      : `learn-more-${section.id}`
+              }
               className="overflow-hidden rounded-2xl border-2 border-border/60 bg-card shadow-soft backdrop-blur"
             >
               <motion.button

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -34,6 +34,12 @@ const PHASE_LOGOS: Partial<Record<Phase['key'], { src: string; alt: string }>> =
   mainnet: { src: '/IMG/Mainnet.svg', alt: 'Mainnet Logo' }
 };
 
+const PHASE_ANCHORS: Partial<Record<Phase['key'], { href: string; ariaLabel: string }>> = {
+  devnet: { href: '#what-is-horizon', ariaLabel: 'Jump to What is Horizon' },
+  testnet: { href: '#what-is-adiri', ariaLabel: 'Jump to What is Adiri' },
+  mainnet: { href: '#what-is-mainnet', ariaLabel: 'Jump to What is Mainnet' }
+};
+
 type PhaseOverviewProps = {
   phases: Phase[];
 };
@@ -69,15 +75,12 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
           const badge = STATUS_LABELS[phase.status];
           const Icon = NetworkIcon;
           const logo = PHASE_LOGOS[phase.key];
+          const anchor = PHASE_ANCHORS[phase.key];
 
           const subtitle = 'Release';
 
-          return (
-            <motion.article
-              key={phase.key}
-              className="group flex h-full flex-col gap-5 rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow focus-within:-translate-y-1"
-              whileHover={{ y: -8 }}
-            >
+          const cardInner = (
+            <>
               <header className="flex items-start justify-between gap-4">
                 <div className="flex items-center gap-3">
                   <div className="flex h-9 w-9 items-center justify-center rounded-2xl bg-primary/10 text-primary md:h-10 md:w-10">
@@ -120,6 +123,34 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
               <p className="text-sm leading-relaxed text-fg-muted transition group-hover:text-fg">
                 {phase.summary}
               </p>
+            </>
+          );
+
+          if (anchor) {
+            return (
+              <a
+                key={phase.key}
+                href={anchor.href}
+                aria-label={anchor.ariaLabel}
+                className="group block focus:outline-none"
+              >
+                <motion.article
+                  className="flex h-full flex-col gap-5 rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow"
+                  whileHover={{ y: -8 }}
+                >
+                  {cardInner}
+                </motion.article>
+              </a>
+            );
+          }
+
+          return (
+            <motion.article
+              key={phase.key}
+              className="group flex h-full flex-col gap-5 rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow"
+              whileHover={{ y: -8 }}
+            >
+              {cardInner}
             </motion.article>
           );
         })}


### PR DESCRIPTION
## Summary
- add stable anchor ids for Learn more sections, update Mainnet body copy, and auto-expand the matching accordion when the hash changes
- wrap Phase overview cards with anchor links so each card scrolls to its corresponding Learn more section

## Testing
- npm run lint *(fails: existing lint errors in src/security/PasswordGate.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68daf18d32f08324bc827413a2970873