### PR TITLE
Improve responsive layout for header and roadmap flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,15 +81,15 @@ export default function App() {
               transition={{ duration: 0.5, ease: 'easeOut' }}
               className="space-y-8"
             >
-              <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-6">
-                  <TelcoinAnimatedLogo className="h-32 w-32 shrink-0" />
-                  <div className="space-y-3 text-left">
+              <div className="flex flex-wrap items-start gap-6 md:flex-nowrap md:justify-between">
+                <div className="flex min-w-0 flex-1 flex-wrap items-start gap-4">
+                  <TelcoinAnimatedLogo className="h-28 w-28 shrink-0 md:h-32 md:w-32" />
+                  <div className="min-w-[220px] flex-1 space-y-3 text-left">
                     <h1 className="text-2xl font-extrabold text-fg md:text-3xl">Telcoin Network Status</h1>
                     <p className="max-w-xl text-sm text-fg-muted md:text-base">{headerDescription}</p>
                   </div>
                 </div>
-                <div className="w-full max-w-sm rounded-3xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
+                <div className="w-full min-w-[260px] max-w-sm rounded-3xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
                   <ProgressBar value={status.meta.overallTrajectoryPct} label="Road to Mainnet" />
                   <p className="mt-4 text-sm text-fg-muted">
                     Last updated <time dateTime={status.meta.lastUpdated}>{formattedLastUpdated}</time>

--- a/src/components/RoadToDeployment/Flow.tsx
+++ b/src/components/RoadToDeployment/Flow.tsx
@@ -74,7 +74,7 @@ function RoadmapNode({ data }: NodeProps<FlowNodeData>) {
         onMouseLeave={() => toggleHover(false)}
         onFocus={() => toggleHover(true)}
         onBlur={() => toggleHover(false)}
-        className={`flex min-w-[220px] flex-col gap-3 rounded-2xl border-2 bg-card p-4 text-left shadow-glow transition duration-200 ease-out focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${statusStyle} hover:-translate-y-1 hover:border-primary/50 hover:shadow-[0_25px_55px_-25px_hsl(201_92%_56%/0.45)]`}
+        className={`flex w-[clamp(16rem,80vw,22rem)] min-w-[16rem] flex-col gap-3 rounded-2xl border-2 bg-card p-4 text-left shadow-glow transition duration-200 ease-out focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg ${statusStyle} hover:-translate-y-1 hover:border-primary/50 hover:shadow-[0_25px_55px_-25px_hsl(201_92%_56%/0.45)]`}
       >
         <span className="text-xs font-semibold uppercase tracking-[0.2em] text-fg-muted/80">
           {phase.subtitle ?? 'Milestone'}
@@ -239,8 +239,9 @@ export function RoadToDeploymentFlow({ onSelectPhase }: FlowProps) {
         </div>
       </header>
       <div
-        className="rounded-3xl border-2 border-border/60 bg-card/80 p-6 shadow-glow h-[32rem] md:h-[26rem]"
+        className="rounded-3xl border-2 border-border/60 bg-card/80 p-6 shadow-glow"
         data-testid="roadmap-flow"
+        style={{ height: 'clamp(28rem, 70vh, 40rem)' }}
       >
         <ReactFlow
           nodes={nodes}


### PR DESCRIPTION
## Summary
- keep the hero header layout stable across breakpoints while allowing it to wrap gracefully on small screens
- adjust roadmap flow node sizing and container height so the diagram scales with the viewport without clipping content

## Testing
- npm run build:nogate

------
https://chatgpt.com/codex/tasks/task_e_68dbd4cd832483309d503cb2d43577ba