### PR TITLE
feat: sync phase milestones hover dropdowns with Road to Mainnet tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,7 +157,7 @@ export default function App() {
               viewport={{ once: true, amount: 0.3 }}
               transition={{ duration: 0.5, ease: 'easeOut', delay: 0.05 }}
             >
-              <RoadToMainnet steps={status.roadmap} />
+              <RoadToMainnet />
             </motion.section>
 
             <motion.section

--- a/src/components/MilestoneDropdown.tsx
+++ b/src/components/MilestoneDropdown.tsx
@@ -1,0 +1,79 @@
+import { useState, type FocusEventHandler } from 'react';
+import type { PhaseKey } from '@/data/milestones';
+import { MILESTONES } from '@/data/milestones';
+import { requestRoadToMainnetTab } from '@/utils/roadToMainnet';
+
+import CheckIconUrl from '/IMG/Checkmark.svg?url';
+
+type Props = { phase: PhaseKey };
+
+export default function MilestoneDropdown({ phase }: Props) {
+  const [open, setOpen] = useState(false);
+  const items = MILESTONES[phase];
+
+  const handleFocusOut: FocusEventHandler<HTMLDivElement> = (event) => {
+    if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      setOpen(false);
+    }
+  };
+
+  const handleMilestoneClick = () => {
+    requestRoadToMainnetTab(phase, { scroll: true });
+  };
+
+  return (
+    <div
+      className="mt-5"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onFocus={() => setOpen(true)}
+      onBlur={handleFocusOut}
+    >
+      <div
+        className="inline-flex cursor-default items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-white/90"
+        aria-expanded={open}
+        data-phase-card-milestones-toggle=""
+        tabIndex={0}
+      >
+        <span>Milestones</span>
+        <svg
+          className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`}
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.23 7.21a.75.75 0 011.06.02L10 10.174l3.71-2.943a.75.75 0 11.94 1.166l-4.24 3.363a.75.75 0 01-.94 0L5.21 8.396a.75.75 0 01.02-1.186z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+
+      <div
+        className={`overflow-hidden transition-[max-height,opacity] duration-300 ${open ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}
+        data-phase-card-milestones-panel=""
+      >
+        <ul className="mt-3 space-y-2">
+          {items.map((m, i) => (
+            <li key={i}>
+              <button
+                type="button"
+                onClick={handleMilestoneClick}
+                className="flex w-full items-start gap-3 rounded-lg px-1 py-1 text-left text-white/90 transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/40"
+                data-phase-card-milestones-item=""
+              >
+                {m.done ? (
+                  <img src={CheckIconUrl} alt="" className="mt-0.5 h-4 w-4 shrink-0" />
+                ) : (
+                  <span className="mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full bg-white/50" />
+                )}
+                <span className="text-sm leading-6">{m.text}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -1,5 +1,7 @@
 import { motion, useReducedMotion } from 'framer-motion';
 
+import MilestoneDropdown from '@/components/MilestoneDropdown';
+import type { PhaseKey } from '@/data/milestones';
 import HorizonLogoUrl from '@/assets/horizon.svg?url';
 import AdiriLogoUrl from '@/assets/adiri.svg?url';
 import type { Phase } from '../data/statusSchema';
@@ -32,6 +34,12 @@ const PHASE_LOGOS: Partial<Record<Phase['key'], { src: string; alt: string }>> =
   devnet: { src: HorizonLogoUrl, alt: 'Horizon logo' },
   testnet: { src: AdiriLogoUrl, alt: 'Adiri logo' },
   mainnet: { src: '/IMG/Mainnet.svg', alt: 'Mainnet Logo' }
+};
+
+const PHASE_TO_DROPDOWN_KEY: Record<Phase['key'], PhaseKey> = {
+  devnet: 'horizon',
+  testnet: 'adiri',
+  mainnet: 'mainnet'
 };
 
 const PHASE_ANCHORS: Partial<Record<Phase['key'], { href: string; ariaLabel: string }>> = {
@@ -78,6 +86,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
           const anchor = PHASE_ANCHORS[phase.key];
 
           const subtitle = 'Release';
+          const milestonePhaseKey = PHASE_TO_DROPDOWN_KEY[phase.key];
 
           const cardInner = (
             <>
@@ -123,6 +132,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
               <p className="text-sm leading-relaxed text-fg-muted transition group-hover:text-fg">
                 {phase.summary}
               </p>
+              <MilestoneDropdown phase={milestonePhaseKey} />
             </>
           );
 

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -1,66 +1,91 @@
-import type { ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PhaseKey } from '@/data/milestones';
+import { MILESTONES } from '@/data/milestones';
+import CheckIconUrl from '/IMG/Checkmark.svg?url';
+import {
+  ROAD_TO_MAINNET_EVENT,
+  type RoadToMainnetEventDetail,
+} from '@/utils/roadToMainnet';
 
-import type { RoadmapItem } from '../data/statusSchema';
-import { ChevronIcon, LaunchIcon } from './icons';
-
-type RoadToMainnetProps = {
-  steps: RoadmapItem[];
+const TAB_LABELS: Record<PhaseKey, string> = {
+  horizon: 'Horizon',
+  adiri: 'Adiri',
+  mainnet: 'Mainnet',
 };
 
-const STATE_STYLES: Record<
-  RoadmapItem['state'],
-  { border: string; label: string; icon: ReactNode; chip: string }
-> = {
-  in_progress: {
-    border: 'border-primary/50',
-    label: 'In progress',
-    icon: (
-      <img
-        src="/IMG/Loading.svg"
-        alt="In progress"
-        className="h-4 w-4 md:h-5 md:w-5 shrink-0"
-        loading="eager"
-      />
-    ),
-    chip: 'bg-primary/15 text-primary'
-  },
-  up_next: {
-    border: 'border-border/80',
-    label: 'Up next',
-    icon: (
-      <img
-        src="/IMG/coming.svg"
-        alt="Up next"
-        className="h-4 w-4 md:h-5 md:w-5 shrink-0"
-        loading="eager"
-      />
-    ),
-    chip: 'bg-white/10 text-fg-muted'
-  },
-  planned: {
-    border: 'border-border/80',
-    label: 'Planned',
-    icon: (
-      <img
-        src="/IMG/Info.svg"
-        alt="Planned"
-        className="h-4 w-4 md:h-5 md:w-5 shrink-0"
-        loading="eager"
-      />
-    ),
-    chip: 'bg-white/5 text-fg-muted'
-  },
-  complete: {
-    border: 'border-success/40',
-    label: 'Complete',
-    icon: <LaunchIcon className="h-4 w-4 md:h-5 md:w-5" aria-hidden="true" />,
-    chip: 'bg-success/15 text-success'
-  }
-};
+export function RoadToMainnet() {
+  const [tab, setTab] = useState<PhaseKey>('horizon');
+  const tabs: PhaseKey[] = ['horizon', 'adiri', 'mainnet'];
+  const sectionRef = useRef<HTMLElement | null>(null);
 
-export function RoadToMainnet({ steps }: RoadToMainnetProps) {
+  const HASH_PREFIX = '#road-to-mainnet-tab-';
+
+  const handleTabSelect = useCallback(
+    (phase: PhaseKey, options?: { scroll?: boolean; updateHash?: boolean }) => {
+      setTab(phase);
+
+      if (typeof window !== 'undefined' && options?.updateHash !== false) {
+        const targetHash = `${HASH_PREFIX}${phase}`;
+        if (window.location.hash !== targetHash) {
+          window.history.replaceState(null, '', targetHash);
+        }
+      }
+
+      if (options?.scroll && sectionRef.current) {
+        sectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const validPhases: PhaseKey[] = ['horizon', 'adiri', 'mainnet'];
+
+    const applyHash = () => {
+      const hash = window.location.hash;
+      if (hash.startsWith(HASH_PREFIX)) {
+        const candidate = hash.slice(HASH_PREFIX.length) as PhaseKey;
+        if (validPhases.includes(candidate)) {
+          handleTabSelect(candidate, { updateHash: false });
+        }
+      }
+    };
+
+    applyHash();
+
+    const handleHashChange = () => {
+      applyHash();
+    };
+
+    const handleEvent = (event: Event) => {
+      const detail = (event as CustomEvent<RoadToMainnetEventDetail>).detail;
+      if (!detail) {
+        return;
+      }
+
+      handleTabSelect(detail.phase, { scroll: detail.scroll });
+    };
+
+    window.addEventListener('hashchange', handleHashChange);
+    document.addEventListener(ROAD_TO_MAINNET_EVENT, handleEvent as EventListener);
+
+    return () => {
+      window.removeEventListener('hashchange', handleHashChange);
+      document.removeEventListener(ROAD_TO_MAINNET_EVENT, handleEvent as EventListener);
+    };
+  }, [HASH_PREFIX, handleTabSelect]);
+
   return (
-    <section aria-labelledby="roadmap-heading" className="space-y-6">
+    <section
+      ref={sectionRef}
+      aria-labelledby="roadmap-heading"
+      className="space-y-6"
+      data-road-to-mainnet=""
+    >
       <div className="flex items-start gap-3">
         <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/20 text-primary">
           <img
@@ -80,28 +105,46 @@ export function RoadToMainnet({ steps }: RoadToMainnetProps) {
         </div>
       </div>
       <div className="rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
-        <ol className="space-y-4">
-          {steps.map((step) => {
-            const style = STATE_STYLES[step.state];
+        <div className="mb-5 inline-flex rounded-xl bg-white/5 p-1" role="tablist" aria-label="Road to Mainnet phases">
+          {tabs.map((t) => {
+            const selected = tab === t;
             return (
-              <li
-                key={step.title}
-                className="flex flex-col gap-3 rounded-2xl border-2 border-white/10 bg-white/5 p-4 text-sm text-fg backdrop-blur"
+              <button
+                key={t}
+                type="button"
+                id={`road-to-mainnet-tab-${t}`}
+                onClick={() => handleTabSelect(t)}
+                className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${selected ? 'bg-white/15 text-white' : 'text-white/70 hover:text-white/90'}`}
+                role="tab"
+                aria-selected={selected}
+                aria-controls={`road-to-mainnet-panel-${t}`}
+                data-road-to-mainnet-tab={t}
               >
-                <div className="flex items-center justify-between gap-3">
-                  <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${style.chip}`}>
-                    <span className="flex h-7 w-7 items-center justify-center rounded-full bg-primary/15 text-primary shadow-soft" aria-hidden="true">
-                      {style.icon}
-                    </span>
-                    {style.label}
-                  </span>
-                  <ChevronIcon className="h-4 w-4 text-fg-muted/80" aria-hidden="true" />
-                </div>
-                <h3 className="text-base font-semibold text-fg">{step.title}</h3>
-              </li>
+                {TAB_LABELS[t]}
+              </button>
             );
           })}
-        </ol>
+        </div>
+
+        <div
+          id={`road-to-mainnet-panel-${tab}`}
+          role="tabpanel"
+          aria-labelledby={`road-to-mainnet-tab-${tab}`}
+          data-road-to-mainnet-panel={tab}
+        >
+          <ul className="space-y-2">
+            {MILESTONES[tab].map((m, i) => (
+              <li key={i} className="flex items-start gap-3">
+                {m.done ? (
+                  <img src={CheckIconUrl} alt="" className="mt-0.5 h-4 w-4 shrink-0" />
+                ) : (
+                  <span className="mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full bg-white/50" />
+                )}
+                <span className="text-sm leading-6 text-white/90">{m.text}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </section>
   );

--- a/src/data/milestones.ts
+++ b/src/data/milestones.ts
@@ -1,0 +1,20 @@
+export type PhaseKey = 'horizon' | 'adiri' | 'mainnet';
+
+export type Milestone = { text: string; done?: boolean };
+
+export const MILESTONES: Record<PhaseKey, Milestone[]> = {
+  horizon: [
+    { text: 'Patch Public Vulnerabilities', done: true },
+    { text: 'Stabilize Horizon Environment' },
+    { text: 'Security Findings Final Patches' },
+  ],
+  adiri: [
+    { text: 'Genesis Ceremony w/ MNO Partners' },
+    { text: 'MNO Onboarding' },
+    { text: 'Integrate Testnets w/ Bridge Solution' },
+    { text: 'Adiri Alpha Audits' },
+  ],
+  mainnet: [
+    { text: 'Launch' },
+  ],
+};

--- a/src/utils/roadToMainnet.ts
+++ b/src/utils/roadToMainnet.ts
@@ -1,0 +1,20 @@
+import type { PhaseKey } from '@/data/milestones';
+
+export const ROAD_TO_MAINNET_EVENT = 'road-to-mainnet:set-tab';
+
+export type RoadToMainnetEventDetail = {
+  phase: PhaseKey;
+  scroll?: boolean;
+};
+
+export function requestRoadToMainnetTab(phase: PhaseKey, options?: { scroll?: boolean }) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.dispatchEvent(
+    new CustomEvent<RoadToMainnetEventDetail>(ROAD_TO_MAINNET_EVENT, {
+      detail: { phase, scroll: options?.scroll },
+    }),
+  );
+}

--- a/status.json
+++ b/status.json
@@ -4,7 +4,7 @@
     {
       "key": "devnet",
       "title": "Horizon",
-      "status": "in_progress",
+      "status": "upcoming",
       "summary": "Finalizing high-priority security fixes and validating the Horizon development environment ahead of broader testing."
     },
     {


### PR DESCRIPTION
## Summary
- set the Horizon phase to Upcoming so the badge reflects the latest status
- add shared milestone data and a per-card dropdown component that now opens on hover and links to the Road to Mainnet tabs
- replace the Road to Mainnet list with a tabbed milestone view that syncs with dropdown interactions

## Testing
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbfa6e2e58833082133fe600070891