### PR TITLE
feat: open phase milestones and enrich road to mainnet details

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,7 +157,7 @@ export default function App() {
               viewport={{ once: true, amount: 0.3 }}
               transition={{ duration: 0.5, ease: 'easeOut', delay: 0.05 }}
             >
-              <RoadToMainnet steps={status.roadmap} />
+              <RoadToMainnet />
             </motion.section>
 
             <motion.section

--- a/src/components/MilestoneDropdown.tsx
+++ b/src/components/MilestoneDropdown.tsx
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+import type { PhaseKey } from '@/data/milestones';
+import { MILESTONES } from '@/data/milestones';
+import { requestRoadToMainnetTab } from '@/utils/roadToMainnet';
+
+import CheckIconUrl from '/IMG/Checkmark.svg?url';
+
+type Props = { phase: PhaseKey };
+
+export default function MilestoneDropdown({ phase }: Props) {
+  const items = MILESTONES[phase];
+
+  const handleMilestoneClick = useCallback(() => {
+    requestRoadToMainnetTab(phase, { scroll: true });
+  }, [phase]);
+
+  return (
+    <div className="mt-6 space-y-4" data-phase-card-milestones="">
+      <div
+        className="flex w-full items-center justify-between gap-2 rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-white/70"
+        data-phase-card-milestones-header=""
+      >
+        <span className="text-white/80">Milestones</span>
+        <span className="text-[0.65rem] font-medium tracking-[0.24em] text-white/40">Road to Mainnet</span>
+      </div>
+
+      <ul className="space-y-3" data-phase-card-milestones-list="">
+        {items.map((m, i) => (
+          <li key={i}>
+            <a
+              href="#roadmap-heading"
+              onClick={handleMilestoneClick}
+              className="group flex w-full items-start gap-3 rounded-xl border border-white/5 bg-white/0 px-3 py-3 text-left text-white/90 transition hover:border-white/10 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/40"
+              data-phase-card-milestones-item=""
+            >
+              {m.done ? (
+                <img src={CheckIconUrl} alt="" className="mt-0.5 h-4 w-4 shrink-0" />
+              ) : (
+                <span className="mt-[6px] h-1.5 w-1.5 shrink-0 rounded-full bg-white/50" />
+              )}
+              <span className="text-sm leading-6 text-white/90 group-hover:text-white">{m.text}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -1,7 +1,10 @@
 import { motion, useReducedMotion } from 'framer-motion';
 
+import MilestoneDropdown from '@/components/MilestoneDropdown';
+import type { PhaseKey } from '@/data/milestones';
 import HorizonLogoUrl from '@/assets/horizon.svg?url';
 import AdiriLogoUrl from '@/assets/adiri.svg?url';
+import { requestRoadToMainnetTab } from '@/utils/roadToMainnet';
 import type { Phase } from '../data/statusSchema';
 import { NetworkIcon } from './icons';
 import { formatList } from '../utils/formatList';
@@ -34,10 +37,10 @@ const PHASE_LOGOS: Partial<Record<Phase['key'], { src: string; alt: string }>> =
   mainnet: { src: '/IMG/Mainnet.svg', alt: 'Mainnet Logo' }
 };
 
-const PHASE_ANCHORS: Partial<Record<Phase['key'], { href: string; ariaLabel: string }>> = {
-  devnet: { href: '#what-is-horizon', ariaLabel: 'Jump to What is Horizon' },
-  testnet: { href: '#what-is-adiri', ariaLabel: 'Jump to What is Adiri' },
-  mainnet: { href: '#what-is-mainnet', ariaLabel: 'Jump to What is Mainnet' }
+const PHASE_TO_DROPDOWN_KEY: Record<Phase['key'], PhaseKey> = {
+  devnet: 'horizon',
+  testnet: 'adiri',
+  mainnet: 'mainnet'
 };
 
 type PhaseOverviewProps = {
@@ -75,9 +78,13 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
           const badge = STATUS_LABELS[phase.status];
           const Icon = NetworkIcon;
           const logo = PHASE_LOGOS[phase.key];
-          const anchor = PHASE_ANCHORS[phase.key];
+          const anchor = {
+            href: '#roadmap-heading',
+            ariaLabel: `Jump to Road to Mainnet milestones for ${phase.title}`,
+          };
 
           const subtitle = 'Release';
+          const milestonePhaseKey = PHASE_TO_DROPDOWN_KEY[phase.key];
 
           const cardInner = (
             <>
@@ -123,6 +130,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
               <p className="text-sm leading-relaxed text-fg-muted transition group-hover:text-fg">
                 {phase.summary}
               </p>
+              <MilestoneDropdown phase={milestonePhaseKey} />
             </>
           );
 
@@ -133,6 +141,10 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
                 href={anchor.href}
                 aria-label={anchor.ariaLabel}
                 className="group block focus:outline-none"
+                onClick={(event) => {
+                  event.preventDefault();
+                  requestRoadToMainnetTab(milestonePhaseKey, { scroll: true });
+                }}
               >
                 <motion.article
                   className="flex h-full flex-col gap-5 rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow"

--- a/src/data/milestones.ts
+++ b/src/data/milestones.ts
@@ -1,0 +1,60 @@
+export type PhaseKey = 'horizon' | 'adiri' | 'mainnet';
+
+export type Milestone = { text: string; done?: boolean; details?: string[] };
+
+export const MILESTONES: Record<PhaseKey, Milestone[]> = {
+  horizon: [
+    {
+      text: 'Patch Public Vulnerabilities',
+      done: true,
+      details: [
+        'Priority findings addressed and patched',
+        'Confirm patch and code hardening via 3rd party security researchers and community',
+      ],
+    },
+    {
+      text: 'Stabilize Horizon Environment',
+      details: ['Deploy public devnet nodes', 'Reset telscan.io'],
+    },
+    {
+      text: 'Security Findings Final Patches',
+      details: [
+        'After Priority Fixes (remaining) completed',
+        'Confirm patch and code hardening',
+      ],
+    },
+  ],
+  adiri: [
+    {
+      text: 'Genesis Opening Ceremony with MNO Partners',
+      details: [
+        'Adiri testnet genesis ceremony with MNO partners',
+        'Begin onboarding MNO partners to Adiri testnet',
+      ],
+    },
+    {
+      text: 'MNO Onboarding',
+      details: ['White glove onboarding MNO partners to Adiri testnet'],
+    },
+    {
+      text: 'Integrate Adiri Testnets with Bridge Solution',
+      details: ['Bridge integration for Adiri Testnet'],
+    },
+    {
+      text: 'Adiri Alpha Audits',
+      details: [
+        'RecoverableWrapper',
+        'BLS library',
+        'Libp2p',
+        'State sync',
+        'Execution layer',
+        'Cryptographic key management',
+        'Bridge',
+        'Competition',
+      ],
+    },
+  ],
+  mainnet: [
+    { text: 'Launch' },
+  ],
+};

--- a/src/utils/roadToMainnet.ts
+++ b/src/utils/roadToMainnet.ts
@@ -1,0 +1,20 @@
+import type { PhaseKey } from '@/data/milestones';
+
+export const ROAD_TO_MAINNET_EVENT = 'road-to-mainnet:set-tab';
+
+export type RoadToMainnetEventDetail = {
+  phase: PhaseKey;
+  scroll?: boolean;
+};
+
+export function requestRoadToMainnetTab(phase: PhaseKey, options?: { scroll?: boolean }) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.dispatchEvent(
+    new CustomEvent<RoadToMainnetEventDetail>(ROAD_TO_MAINNET_EVENT, {
+      detail: { phase, scroll: options?.scroll },
+    }),
+  );
+}

--- a/status.json
+++ b/status.json
@@ -4,7 +4,7 @@
     {
       "key": "devnet",
       "title": "Horizon",
-      "status": "in_progress",
+      "status": "upcoming",
       "summary": "Finalizing high-priority security fixes and validating the Horizon development environment ahead of broader testing."
     },
     {


### PR DESCRIPTION
## Summary
- set the Horizon phase to Upcoming so the badge reflects the latest status
- add shared milestone data and per-card milestone headers that stay open while linking into the Road to Mainnet tabs
- replace the Road to Mainnet list with a tabbed milestone view that now includes detailed copy for each milestone

## Testing
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbfa6e2e58833082133fe600070891