### PR TITLE
Add header resource buttons and improve progress visuals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,32 @@ export default function App() {
                     <p className="max-w-xl text-sm text-fg-muted md:text-base">
                       {headerDescription}
                     </p>
+                    <div className="flex flex-wrap gap-3">
+                      <a
+                        href="https://github.com/telcoin-association/telcoin-network"
+                        className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        GitHub
+                      </a>
+                      <a
+                        href="https://telscan.io/"
+                        className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Explorer
+                      </a>
+                      <a
+                        href="https://www.telcoin.network/faucet"
+                        className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Faucet
+                      </a>
+                    </div>
                   </div>
                 </div>
                 <div className="w-full min-w-[260px] max-w-sm rounded-3xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -129,7 +129,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
                   {badge.text}
                 </motion.span>
               </header>
-              <p className="text-sm leading-relaxed text-fg-muted transition group-hover:text-fg">
+              <p className="flex-1 text-sm leading-relaxed text-fg-muted transition group-hover:text-fg">
                 {phase.summary}
               </p>
               <MilestoneBlock phase={milestonePhaseKey} />

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -25,7 +25,7 @@ export function ProgressBar({ value, label }: ProgressBarProps) {
         </div>
       ) : null}
       <div
-        className="relative h-3 w-full overflow-hidden rounded-full bg-border/50"
+        className="relative h-3 w-full overflow-hidden rounded-full border border-white/30 bg-border/40"
         role="progressbar"
         aria-label={label ?? 'Overall progress'}
         aria-valuenow={clampedValue}

--- a/status.json
+++ b/status.json
@@ -4,7 +4,7 @@
     {
       "key": "devnet",
       "title": "Horizon",
-      "status": "upcoming",
+      "status": "in_progress",
       "summary": "Finalizing high-priority security fixes and validating the Horizon development environment ahead of broader testing."
     },
     {


### PR DESCRIPTION
## Summary
- add GitHub, Explorer, and Faucet links beneath the header description
- align milestone buttons across overview cards by allowing summaries to flex
- update Horizon phase status and emphasize the progress bar track border

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc18d8521083248fd83a6350eb34f9