### PR TITLE
Align milestone badges in phase overview

### DIFF
--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -144,7 +144,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
                   {phase.summary}
                 </p>
               </div>
-              <div className="mt-auto pt-4" data-milestones-row="">
+              <div className="pt-4" data-milestones-row="">
                 <MilestoneBlock phase={milestonePhaseKey} />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- remove the extra auto margin that pinned the milestone block to the bottom of each phase card
- allow the milestone headers to align consistently across cards regardless of the number of milestone items

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc2ac2080083248f5ffb21440eaf32