### PR TITLE
Add Docs header link and move last updated into progress card

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,16 +115,26 @@ export default function App() {
                       >
                         Faucet
                       </a>
+                      <a
+                        href="https://docs.telcoin.network/telcoin-network/"
+                        className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Docs
+                      </a>
                     </div>
                   </div>
                 </a>
                 <div className="flex w-full min-w-[260px] max-w-sm flex-col items-start gap-4 md:items-end">
-                  <LastUpdated />
                   <div className="w-full rounded-3xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
                     <ProgressBar
                       value={status.meta.overallTrajectoryPct}
                       label="Road to Mainnet"
                     />
+                    <div className="mt-4 flex w-full justify-end">
+                      <LastUpdated />
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add a Docs button to the header links alongside GitHub, Explorer, and Faucet
- move the last updated timestamp into the Road to Mainnet progress card beneath the bar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc40927c648324ac243559f437dc65