### PR TITLE
Add Track Issues tab to roadmap and polish UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,12 +117,12 @@ export default function App() {
                           Explorer
                         </a>
                         <a
-                          href="https://www.telcoin.network/faucet"
+                          href="https://github.com/Telcoin-Association/telcoin-network/issues"
                           className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                           target="_blank"
                           rel="noreferrer"
                         >
-                          Faucet
+                          Track Issues
                         </a>
                         <a
                           href="https://docs.telcoin.network/telcoin-network/"
@@ -142,7 +142,7 @@ export default function App() {
                       value={status.meta.overallTrajectoryPct}
                       label="Road to Mainnet"
                     />
-                    <div className="mt-4 flex w-full justify-end">
+                    <div className="mt-4 flex w-full justify-center">
                       <LastUpdated />
                     </div>
                   </div>

--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -16,8 +16,8 @@ const LEARN_MORE_CONTENT: Record<Phase['key'], { title: string; body: string[] }
   devnet: {
     title: 'What is Horizon',
     body: [
-      "Horizon (also referred to as Devnet) is Telcoin Network's development environment—a public testing ground where new features, protocol upgrades, and network improvements are first deployed and tested.",
-      'Like all development networks, Horizon is designed for experimentation. Developers can build applications, test integrations, and explore network capabilities using test tokens that have no real-world value. This creates a safe space for innovation without financial risk, though it also means the network may occasionally break or restart as new code is deployed—this instability is completely normal and expected.',
+      "Horizon (also referred to as Devnet) is Telcoin Network's development environment a public testing ground where new features, protocol upgrades, and network improvements are first deployed and tested.",
+      'Like all development networks, Horizon is designed for experimentation. Developers can build applications, test integrations, and explore network capabilities using test tokens that have no real-world value. This creates a safe space for innovation without financial risk, though it also means the network may occasionally break or restart as new code is deployed this instability is completely normal and expected.',
       'Our current priority is addressing security vulnerabilities identified during our recent 4-week public security competition. By fixing these issues on Horizon first, we ensure that bad actors cannot exploit these weaknesses when the network moves to higher-stakes environments.',
       "Horizon serves as the essential first step in our three-stage deployment process: Devnet → Testnet → Mainnet. Every piece of code must prove itself here before advancing to the next stage. Once Horizon demonstrates the necessary stability and security, we'll be ready to progress to Adiri, where broader ecosystem testing with external partners can begin.",
     ],
@@ -25,17 +25,17 @@ const LEARN_MORE_CONTENT: Record<Phase['key'], { title: string; body: string[] }
   testnet: {
     title: 'What is Adiri',
     body: [
-      'Adiri is Telcoin Network’s public testnet, where the community and partners—including mobile network operators (MNOs) spinning up validator nodes—can interact with the network in a live but non-production setting.',
+      'Adiri is Telcoin Network’s public testnet, where the community and partners including mobile network operators (MNOs) spinning up validator nodes can interact with the network in a live but non-production setting.',
       'This stage follows Horizon stabilization and will roll out in phases. Early iterations of Adiri may still see instability or bugs as the network undergoes continuous upgrades and audit cycles. That’s intentional: Adiri is where real-world testing happens, and where we make sure validator participation, governance mechanics, and protocol updates all function securely before moving to mainnet.',
-      'Adiri represents a critical milestone because it’s the first time the broader ecosystem—validators, developers, and community members—can meaningfully engage with Telcoin Network.',
+      'Adiri represents a critical milestone because it’s the first time the broader ecosystem validators, developers, and community members can meaningfully engage with Telcoin Network.',
     ],
   },
   mainnet: {
     title: 'What is Mainnet',
     body: [
-      'Mainnet represents the full launch of Telcoin Network—the moment we transition from testing to production and deliver a live, fully operational Layer 1 blockchain.ale operation. Together, these phases deliver the security and decentralization guarantees expected of a Layer 1 blockchain.',
+      'Mainnet represents the full launch of Telcoin Network the moment we transition from testing to production and deliver a live, fully operational Layer 1 blockchain.ale operation. Together, these phases deliver the security and decentralization guarantees expected of a Layer 1 blockchain.',
       'This is where everything becomes real. Mainnet will use actual Telcoin (TEL) as its native currency, enabling genuine value transfer, real economic activity, and production-ready application deployment. Unlike the testing phases, every transaction, every smart contract, and every piece of value on Mainnet will have real-world significance.',
-      'Mainnet is the culmination of all our development efforts—the secure, decentralized network that validators, developers, and users can trust for critical operations. After proving our technology through rigorous testing on Horizon and Adiri, Mainnet represents our commitment to delivering the security, performance, and decentralization guarantees expected of a world-class L1 blockchain.',
+      'Mainnet is the culmination of all our development efforts the secure, decentralized network that validators, developers, and users can trust for critical operations. After proving our technology through rigorous testing on Horizon and Adiri, Mainnet represents our commitment to delivering the security, performance, and decentralization guarantees expected of a world-class L1 blockchain.',
       'For the Telcoin community, Mainnet launch marks a pivotal milestone: the transformation of years of development into a live network that will power the future of accessible financial services. This is when Telcoin Network stops being a promise and becomes a standard.',
     ],
   },
@@ -102,7 +102,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
   const linkButtons = [
     { label: 'Governance Forum', href: links.governanceForum },
     { label: 'Technical Docs', href: links.technicalDocs },
-    { label: 'Faucet', href: 'https://www.telcoin.network/faucet' },
+    { label: 'Track Issues', href: 'https://github.com/Telcoin-Association/telcoin-network/issues' },
     { label: 'Telcoin Association', href: 'https://www.telcoin.org/' },
     { label: 'Telcoin TAO Twitter', href: 'https://x.com/TelcoinTAO' },
   ];

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -15,7 +15,7 @@ const STATUS_LABELS: Record<
   { text: string; className: string; ariaLabel: string; shouldPulse?: boolean }
 > = {
   in_progress: {
-    text: 'In progress',
+    text: 'Active',
     className: 'border-primary/50 bg-primary/20 text-primary',
     ariaLabel: 'Phase is in progress',
     shouldPulse: true

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -1,12 +1,38 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { PhaseKey } from '@/data/milestones';
 import { MILESTONES } from '@/data/milestones';
 import { ROAD_TO_MAINNET_SECTION_ID, roadToMainnetId } from '@/utils/ids';
 
-const TABS: PhaseKey[] = ['horizon', 'adiri', 'mainnet'];
+type TabKey = PhaseKey | 'issues';
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: 'horizon', label: 'Horizon' },
+  { key: 'adiri', label: 'Adiri' },
+  { key: 'mainnet', label: 'Mainnet' },
+  { key: 'issues', label: 'Track Issues' }
+];
+
+type IssueLabel = { id: number; name: string };
+
+type Issue = {
+  id: number;
+  number: number;
+  title: string;
+  html_url: string;
+  updated_at: string;
+  labels: IssueLabel[];
+  pull_request?: unknown;
+};
+
+const ISSUES_API_URL =
+  'https://api.github.com/repos/Telcoin-Association/telcoin-network/issues?state=open&per_page=100';
 
 export default function RoadToMainnet() {
-  const [tab, setTab] = useState<PhaseKey>('horizon');
+  const [tab, setTab] = useState<TabKey>('horizon');
+  const [issuesState, setIssuesState] = useState<{
+    status: 'idle' | 'loading' | 'error' | 'success';
+    data: Issue[];
+  }>({ status: 'idle', data: [] });
 
   // On hash change or first load, infer tab from '#road-to-mainnet-{phase}-...'
   useEffect(() => {
@@ -17,7 +43,7 @@ export default function RoadToMainnet() {
     const applyFromHash = () => {
       const hash = window.location.hash.replace(/^#/, '');
       const part = hash.split('-')[3] as PhaseKey | undefined; // road to mainnet {phase} ...
-      if (part && TABS.includes(part)) {
+      if (part && TABS.some((t) => t.key === part)) {
         setTab((prev) => (prev === part ? prev : part));
       }
     };
@@ -42,7 +68,95 @@ export default function RoadToMainnet() {
     }
   }, [tab]);
 
-  const items = useMemo(() => MILESTONES[tab], [tab]);
+  useEffect(() => {
+    if (tab !== 'issues' || issuesState.status !== 'idle') {
+      return;
+    }
+
+    let isMounted = true;
+    setIssuesState({ status: 'loading', data: [] });
+
+    const controller = new AbortController();
+
+    const fetchIssues = async () => {
+      try {
+        const res = await fetch(ISSUES_API_URL, {
+          headers: { Accept: 'application/vnd.github+json' },
+          signal: controller.signal
+        });
+
+        if (!res.ok) {
+          throw new Error('Request failed');
+        }
+
+        const payload = (await res.json()) as Issue[];
+        const issues = payload.filter((issue) => !issue.pull_request);
+
+        if (isMounted) {
+          setIssuesState({ status: 'success', data: issues });
+        }
+      } catch (error) {
+        if (!isMounted || (error instanceof DOMException && error.name === 'AbortError')) {
+          return;
+        }
+
+        setIssuesState({ status: 'error', data: [] });
+      }
+    };
+
+    fetchIssues();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [tab, issuesState.status]);
+
+  const renderIssues = () => {
+    if (issuesState.status === 'loading') {
+      return <div className="text-sm text-white/80">Loading open issues…</div>;
+    }
+
+    if (issuesState.status === 'error') {
+      return <div className="text-sm text-white/80">Couldn’t load issues.</div>;
+    }
+
+    if (issuesState.status === 'success' && issuesState.data.length === 0) {
+      return <div className="text-sm text-white/80">No open issues.</div>;
+    }
+
+    return issuesState.data.map((issue) => {
+      const updatedAt = new Date(issue.updated_at).toLocaleDateString();
+      return (
+        <article
+          key={issue.id}
+          className="rounded-xl border border-white/15 bg-white/10 p-4 text-sm text-white/90 transition hover:border-white/25 hover:bg-white/15"
+        >
+          <a
+            href={issue.html_url}
+            target="_blank"
+            rel="noreferrer"
+            className="font-semibold text-white hover:underline"
+          >
+            {issue.title}
+          </a>
+          {issue.labels?.length ? (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {issue.labels.map((label) => (
+                <span
+                  key={label.id ?? `${issue.id}-${label.name}`}
+                  className="inline-flex items-center rounded-full border border-white/20 px-2 py-0.5 text-xs text-white/80"
+                >
+                  {label.name}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          <div className="mt-2 text-xs text-white/60">#{issue.number} • updated {updatedAt}</div>
+        </article>
+      );
+    });
+  };
 
   return (
     <section
@@ -73,37 +187,47 @@ export default function RoadToMainnet() {
       <div className="rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
         {/* Tabs */}
         <div className="mb-5 inline-flex rounded-xl bg-white/5 p-1">
-          {TABS.map((t) => (
+          {TABS.map(({ key, label }) => (
             <button
-              key={t}
+              key={key}
               type="button"
-              onClick={() => setTab(t)}
+              onClick={() => setTab(key)}
               className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
-                tab === t ? 'bg-white/15 text-white' : 'text-white/70 hover:text-white/90'
+                tab === key ? 'bg-white/15 text-white' : 'text-white/70 hover:text-white/90'
               }`}
-              aria-pressed={tab === t}
+              aria-pressed={tab === key}
             >
-              {t === 'horizon' ? 'Horizon' : t === 'adiri' ? 'Adiri' : 'Mainnet'}
+              {label}
             </button>
           ))}
         </div>
 
         {/* Detail list */}
         <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
-          <ul className="space-y-6">
-            {items.map((m) => (
-              <li key={m.slug} id={roadToMainnetId(tab, m.slug)} className="scroll-mt-24">
-                <div className="text-sm font-semibold text-white/90">{m.text}</div>
-                {m.details && m.details.length > 0 && (
-                  <ul className="mt-2 list-disc pl-5 text-sm leading-6 text-white/80">
-                    {m.details.map((detail, index) => (
-                      <li key={index}>{detail}</li>
-                    ))}
-                  </ul>
-                )}
-              </li>
-            ))}
-          </ul>
+          {tab === 'issues' ? (
+            <section
+              id="issues"
+              className="grid gap-3"
+              aria-live={issuesState.status === 'loading' ? 'polite' : 'off'}
+            >
+              {renderIssues()}
+            </section>
+          ) : (
+            <ul className="space-y-6">
+              {MILESTONES[tab].map((m) => (
+                <li key={m.slug} id={roadToMainnetId(tab, m.slug)} className="scroll-mt-24">
+                  <div className="text-sm font-semibold text-white/90">{m.text}</div>
+                  {m.details && m.details.length > 0 && (
+                    <ul className="mt-2 list-disc pl-5 text-sm leading-6 text-white/80">
+                      {m.details.map((detail, index) => (
+                        <li key={index}>{detail}</li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a Track Issues tab to the Road to Mainnet section that fetches and lists open GitHub issues
- replace Faucet calls-to-action with Track Issues and center the Road to Mainnet timestamp
- clean up Learn More copy and rename the in-progress phase badge to "Active"

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcdd89377083249c3b174e9c4adde0