### PR TITLE
Update faucet CTA and adjust learn more layout

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,2 @@
+/*
+  Content-Security-Policy: default-src 'self'; connect-src 'self' https://api.github.com; img-src 'self' https://avatars.githubusercontent.com https://github.com data:; script-src 'self'; style-src 'self' 'unsafe-inline'; base-uri 'self'; frame-ancestors 'none'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,12 +117,12 @@ export default function App() {
                           Explorer
                         </a>
                         <a
-                          href="https://github.com/Telcoin-Association/telcoin-network/issues"
+                          href="https://www.telcoin.network/faucet"
                           className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/30 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                           target="_blank"
                           rel="noreferrer"
                         >
-                          Track Issues
+                          Faucet
                         </a>
                         <a
                           href="https://docs.telcoin.network/telcoin-network/"

--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -192,7 +192,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
                 role="region"
                 aria-live="polite"
                 aria-hidden={!isOpen}
-                className={`space-y-4 px-6 pb-6 text-sm leading-relaxed text-fg-muted transition-[max-height,opacity] duration-300 ease-out ${isOpen ? 'max-h-[720px] opacity-100' : 'max-h-0 opacity-0'}`}
+                className={`space-y-4 px-6 pb-6 text-sm leading-relaxed text-fg-muted transition-[max-height,opacity] duration-300 ease-out ${isOpen ? 'max-h-[1600px] opacity-100' : 'max-h-0 opacity-0'}`}
               >
                 {section.body.map((paragraph, index) => (
                   <p key={index}>{paragraph}</p>


### PR DESCRIPTION
## Summary
- update the header call-to-action to point to the Telcoin faucet
- add a Netlify `_headers` file with a CSP for production deployments
- expand the Learn More accordion max height so content is not clipped on small screens

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd27092ec4832499f1e96435f394c1