### PR TITLE
chore(ui): apply annotated visual tweaks across roadmap tiles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,7 @@ export default function App() {
                   </div>
                 </div>
                 <div className="flex w-full max-w-full flex-col items-start gap-4 md:w-auto md:min-w-[260px] md:max-w-sm md:items-end">
-                  <div className="w-full rounded-3xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
+                  <div className="w-full border bg-card p-6 backdrop-blur tc-border-cyan-40 tc-radius-16 tc-shadow-cyan-30-20">
                     <ProgressBar
                       value={status.meta.overallTrajectoryPct}
                       label="Road to Mainnet"

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -161,7 +161,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
                   <motion.article
                     data-phase-card=""
                     data-phase={dataPhase}
-                    className="flex h-full flex-col overflow-hidden rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow"
+                    className="flex h-full flex-col overflow-hidden border bg-white/5 p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow tc-border-cadet-60 tc-radius-16"
                     whileHover={{ y: -8 }}
                   >
                     {cardInner}
@@ -176,7 +176,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
               <motion.article
                 data-phase-card=""
                 data-phase={dataPhase}
-                className="group flex h-full flex-col overflow-hidden rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow"
+                className="group flex h-full flex-col overflow-hidden border bg-white/5 p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow tc-border-cadet-60 tc-radius-16"
                 whileHover={{ y: -8 }}
               >
                 {cardInner}

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -160,7 +160,7 @@ export default function RoadToMainnet() {
         </div>
       </div>
 
-      <div className="rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
+      <div className="border bg-white/5 p-6 shadow-soft backdrop-blur tc-border-cadet-60 tc-radius-16">
         {/* Tabs */}
         <div className="mb-5 inline-flex rounded-xl bg-white/5 p-1">
           {TABS.map(({ key, label }) => (
@@ -179,13 +179,17 @@ export default function RoadToMainnet() {
         </div>
 
         {/* Detail list */}
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
+        <div className="border bg-white/5 p-5 tc-border-cadet-60 tc-radius-8">
           {tab === 'issues' ? (
             <section id="issues" style={{ display: 'grid', gap: '12px' }} />
           ) : (
             <ul className="space-y-6">
               {MILESTONES[tab].map((m) => (
-                <li key={m.slug} id={roadToMainnetId(tab, m.slug)} className="scroll-mt-24">
+                <li
+                  key={m.slug}
+                  id={roadToMainnetId(tab, m.slug)}
+                  className="scroll-mt-24 border bg-white/5 transition hover:bg-white/10 tc-border-cadet-60 tc-radius-8"
+                >
                   <div className="text-sm font-semibold text-white/90">{m.text}</div>
                   {m.details && m.details.length > 0 && (
                     <ul className="mt-2 list-disc pl-5 text-sm leading-6 text-white/80">

--- a/src/components/SecurityAudits.tsx
+++ b/src/components/SecurityAudits.tsx
@@ -22,7 +22,10 @@ function StatCard({
 }) {
   const entries = Object.entries(metrics);
   return (
-    <article className="flex flex-1 flex-col gap-4 rounded-2xl border-2 border-border/60 bg-card p-5 shadow-soft backdrop-blur">
+    <article
+      data-priority-findings=""
+      className="flex flex-1 flex-col gap-4 border bg-white/5 p-5 shadow-soft backdrop-blur tc-border-cadet-60 tc-radius-16"
+    >
       <header className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/20 text-primary">
           {icon}
@@ -65,7 +68,10 @@ export function SecurityAudits({ notes, publicFindings, afterPriorityFixes }: Se
         </div>
       </div>
       <div className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
-        <article className="rounded-2xl border-2 border-border/60 bg-card p-6 shadow-soft backdrop-blur">
+        <article
+          data-security-notes=""
+          className="border p-6 shadow-soft backdrop-blur tc-bg-172552 tc-border-cadet-60 tc-radius-16"
+        >
           <h3 className="text-lg font-semibold text-fg">Security notes</h3>
           <ul className="mt-4 space-y-3 text-sm text-fg-muted">
             {notes.map((note) => (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/theme.css';
+import '@/styles/overrides.css';
 import './index.css';
 import PasswordGate from './security/PasswordGate';
 

--- a/src/styles/overrides.css
+++ b/src/styles/overrides.css
@@ -1,0 +1,15 @@
+/* Screenshot-driven tweaks (no layout/content changes) */
+
+/* Cyan outline + soft glow for header status tile */
+.tc-border-cyan-40 { border-color: rgba(25, 200, 255, 0.4); }
+.tc-shadow-cyan-30-20 { filter: drop-shadow(0 10px 30px rgba(25, 200, 255, 0.2)); }
+
+/* Cadet outline used across cards/panels */
+.tc-border-cadet-60 { border-color: rgba(201, 207, 237, 0.6); }
+
+/* Corner radii */
+.tc-radius-16 { border-radius: 16px; }
+.tc-radius-8 { border-radius: 8px; }
+
+/* Security notes tint */
+.tc-bg-172552 { background-color: #172552; }


### PR DESCRIPTION
## Summary
- add centralized override utilities for cyan glow, cadet borders, shared radii, and the security notes tint
- refresh the header status tile plus phase overview and security panels with the requested outlines, radii, and background adjustments
- update the Road to Mainnet container and rows to use the new cadet borders with 16px/8px radii per the annotations

## Testing
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd44fcf0248330ac23abae3e1b6186