### PR TITLE
Use relative path for roadmap fetch

### DIFF
--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -72,7 +72,7 @@ export default function RoadToMainnet() {
 
     (async () => {
       try {
-        const response = await fetch('/roadmap.json', { cache: 'no-store' });
+        const response = await fetch("roadmap.json", { cache: 'no-store' });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }


### PR DESCRIPTION
## Summary
- fetch roadmap data via a relative path so it loads correctly when hosted in subdirectories

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd74d01fb08324a9892fd85855af0f