### PR TITLE
Add Adiri RPC link to Learn More resources

### DIFF
--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -99,6 +99,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
   const linkButtons = [
     { label: 'Governance Forum', href: links.governanceForum },
     { label: 'Technical Docs', href: links.technicalDocs },
+    { label: 'Adiri RPC', href: 'https://chainlist.org/chain/2017' },
     { label: 'Track Issues', href: 'https://github.com/Telcoin-Association/telcoin-network/issues' },
     { label: 'Telcoin Association', href: 'https://www.telcoin.org/' },
     { label: 'Telcoin TAO Twitter', href: 'https://x.com/TelcoinTAO' },


### PR DESCRIPTION
## Summary
- add an Adiri RPC resource button alongside the other Learn More links

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd9ae3f56883249dd3dbef8a43eb21