### PR TITLE
Update Learn more button labels

### DIFF
--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -98,11 +98,11 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
 
   const linkButtons = [
     { label: 'Governance Forum', href: links.governanceForum },
-    { label: 'Technical Docs', href: links.technicalDocs },
+    { label: 'Docs', href: links.technicalDocs },
     { label: 'Adiri RPC', href: 'https://chainlist.org/chain/2017' },
     { label: 'Track Issues', href: 'https://github.com/Telcoin-Association/telcoin-network/issues' },
     { label: 'Telcoin Association', href: 'https://www.telcoin.org/' },
-    { label: 'Telcoin TAO Twitter', href: 'https://x.com/TelcoinTAO' },
+    { label: 'Twitter', href: 'https://x.com/TelcoinTAO' },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- rename the Learn more link buttons to use the updated Docs and Twitter labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9c6ef8b08324972fbf3743883ee6