### PR TITLE
Update Adiri phase naming and milestone breakdown

### DIFF
--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -6,8 +6,8 @@ import { ROAD_TO_MAINNET_SECTION_ID, roadToMainnetId } from '@/utils/ids';
 type TabKey = PhaseKey | 'issues';
 
 const TABS: { key: TabKey; label: string }[] = [
-  { key: 'horizon', label: 'Horizon' },
-  { key: 'adiri', label: 'Adiri' },
+  { key: 'horizon', label: 'Adiri Phase 1' },
+  { key: 'adiri', label: 'Adiri Phase 2' },
   { key: 'mainnet', label: 'Mainnet' },
   { key: 'issues', label: 'Track Issues' }
 ];

--- a/src/data/milestones.ts
+++ b/src/data/milestones.ts
@@ -39,6 +39,19 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
   ],
   adiri: [
     {
+      text: 'Phase 1',
+      slug: 'phase-1',
+      details: [
+        'Patch Public Vulnerabilities',
+        'Stabilize Horizon Environment',
+        'Security Findings Final Patch',
+      ],
+    },
+    {
+      text: 'Phase 2',
+      slug: 'phase-2',
+    },
+    {
       text: 'Genesis Opening Ceremony with MNO Partners',
       slug: 'genesis-opening-ceremony-with-mno-partners',
       details: [


### PR DESCRIPTION
## Summary
- rename the Road to Mainnet Horizon and Adiri tabs to "Adiri Phase 1" and "Adiri Phase 2"
- expand the Adiri milestone list with a Phase 1 grouping and new Phase 2 marker ahead of existing entries

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de2573e9bc8324b2f4f3a790010e10