### PR TITLE
Show Adiri Phase 1 tasks in overview and trim roadmap tab

### DIFF
--- a/src/components/MilestoneBlock.tsx
+++ b/src/components/MilestoneBlock.tsx
@@ -20,6 +20,9 @@ export default function MilestoneBlock({ phase }: Props) {
         {items.map((m, i) => {
           const targetId = roadToMainnetId(phase, m.slug);
           const href = `#${targetId}`;
+          const showAdiriPhaseOneDetails =
+            phase === 'adiri' && m.slug === 'phase-1' && m.details && m.details.length > 0;
+
           return (
             <li key={i} className="flex items-start gap-3">
               {m.done ? (
@@ -27,10 +30,19 @@ export default function MilestoneBlock({ phase }: Props) {
               ) : (
                 <span className="mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full bg-white/50" />
               )}
-              {/* Link ties down to Road to mainnet detail item */}
-              <a href={href} className="text-sm leading-6 text-white/90 hover:underline">
-                {m.text}
-              </a>
+              <div>
+                {/* Link ties down to Road to mainnet detail item */}
+                <a href={href} className="text-sm leading-6 text-white/90 hover:underline">
+                  {m.text}
+                </a>
+                {showAdiriPhaseOneDetails && (
+                  <ul className="mt-1 list-disc pl-5 text-xs leading-5 text-white/80">
+                    {m.details?.map((detail, index) => (
+                      <li key={index}>{detail}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
             </li>
           );
         })}

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -286,7 +286,11 @@ export default function RoadToMainnet() {
             <div id="issues-feed" style={{ display: 'grid', gap: '12px' }} />
           ) : (
             <ul className="space-y-6">
-              {MILESTONES[tab].map((m) => (
+              {MILESTONES[
+                tab
+              ]
+                .filter((m) => !(tab === 'adiri' && m.slug === 'phase-1'))
+                .map((m) => (
                 <li key={m.slug} id={roadToMainnetId(tab, m.slug)} className="scroll-mt-24">
                   <div className="text-sm font-semibold text-white/90">{m.text}</div>
                   {m.details && m.details.length > 0 && (


### PR DESCRIPTION
## Summary
- display the Adiri Phase 1 milestone details directly within the Phase Overview card
- filter out the Phase 1 milestone from the "Adiri Phase 2" Road to Mainnet tab so only Phase 2 work remains

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de28727680832494db1946064582fb