### PR TITLE
Update Adiri phase 2 milestone hierarchy

### DIFF
--- a/src/components/MilestoneBlock.tsx
+++ b/src/components/MilestoneBlock.tsx
@@ -18,7 +18,9 @@ export default function MilestoneBlock({ phase }: Props) {
       {/* Always-open list */}
       <ul className="mt-3 space-y-2">
         {items.map((m, i) => {
-          const targetId = roadToMainnetId(phase, m.slug);
+          const targetSlug =
+            phase === 'adiri' && m.slug === 'phase-1' ? 'phase-2' : m.slug;
+          const targetId = roadToMainnetId(phase, targetSlug);
           const href = `#${targetId}`;
           const showAdiriPhaseOneDetails =
             phase === 'adiri' && m.slug === 'phase-1' && m.details && m.details.length > 0;

--- a/src/data/milestones.ts
+++ b/src/data/milestones.ts
@@ -50,41 +50,11 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
     {
       text: 'Phase 2',
       slug: 'phase-2',
-    },
-    {
-      text: 'Genesis Opening Ceremony with MNO Partners',
-      slug: 'genesis-opening-ceremony-with-mno-partners',
       details: [
-        'Adiri testnet genesis ceremony with MNO partners',
-        'Begin onboarding MNO partners to Adiri testnet',
-      ],
-    },
-    {
-      text: 'MNO Onboarding',
-      slug: 'mno-onboarding',
-      details: [
-        'White glove onboarding MNO partners to Adiri testnet',
-      ],
-    },
-    {
-      text: 'Integrate Adiri Testnets with Bridge Solution',
-      slug: 'integrate-adiri-testnets-with-bridge-solution',
-      details: [
-        'Bridge integration for Adiri Testnet',
-      ],
-    },
-    {
-      text: 'Adiri Alpha Audits',
-      slug: 'adiri-alpha-audits',
-      details: [
-        'RecoverableWrapper',
-        'BLS library',
-        'Libp2p',
-        'State sync',
-        'Execution layer',
-        'Cryptographic key management',
-        'Bridge',
-        'Competition',
+        'Genesis Opening Ceremony with MNO Partners',
+        'MNO Onboarding',
+        'Integrate Adiri Testnets with Bridge Solution',
+        'Adiri Alpha Audits',
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- group the Adiri Phase 2 checklist entries under the Phase 2 milestone in the overview
- retarget the Adiri Phase 1 milestone link so it opens the Adiri Phase 2 tab in Road to Mainnet

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de2b91cad88324a0fcb1ce57a83b30