### PR TITLE
Adjust Learn More layout and Adiri milestones

### DIFF
--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -13,6 +13,9 @@ type LearnMoreProps = {
 };
 
 type LearnMoreSection = { id: string; title: string; body: string[] };
+type LearnMorePhaseSection = LearnMoreSection & { id: Phase['key'] };
+
+const LEARN_MORE_PHASE_ORDER: Phase['key'][] = ['testnet', 'mainnet', 'devnet'];
 
 const LEARN_MORE_CONTENT: Record<Phase['key'], { title: string; body: string[] }> = {
   devnet: {
@@ -73,6 +76,11 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
     [phases]
   );
   const defaultOpenId = useMemo(() => {
+    const hasAdiri = orderedSections.some((section) => section.key === 'testnet');
+    if (hasAdiri) {
+      return 'testnet';
+    }
+
     const activePhase = orderedSections.find(
       (section) => section.status === 'in_progress'
     );
@@ -116,13 +124,25 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
   }, [defaultOpenId]);
 
   const sections = useMemo<LearnMoreSection[]>(() => {
-    const phaseSections = orderedSections.map((section) => ({
+    const phaseSections = orderedSections.map<LearnMorePhaseSection>((section) => ({
       id: section.key,
       title: LEARN_MORE_CONTENT[section.key]?.title ?? 'Learn more',
       body: LEARN_MORE_CONTENT[section.key]?.body ?? ['Details coming soon.'],
     }));
 
-    return [...phaseSections, ...ADDITIONAL_LEARN_MORE_SECTIONS];
+    const sortedPhaseSections = LEARN_MORE_PHASE_ORDER.flatMap((key) =>
+      phaseSections.filter((section) => section.id === key)
+    );
+
+    const remainingPhaseSections = phaseSections.filter(
+      (section) => !LEARN_MORE_PHASE_ORDER.includes(section.id)
+    );
+
+    return [
+      ...sortedPhaseSections,
+      ...remainingPhaseSections,
+      ...ADDITIONAL_LEARN_MORE_SECTIONS,
+    ];
   }, [orderedSections]);
 
   const toggle = (id: string) => {

--- a/src/data/milestones.ts
+++ b/src/data/milestones.ts
@@ -39,19 +39,6 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
   ],
   adiri: [
     {
-      text: 'Phase 1',
-      slug: 'phase-1',
-      details: [
-        'Patch Public Vulnerabilities',
-        'Stabilize Horizon Environment',
-        'Security Findings Final Patch',
-      ],
-    },
-    {
-      text: 'Phase 2',
-      slug: 'phase-2',
-    },
-    {
       text: 'Genesis Opening Ceremony with MNO Partners',
       slug: 'genesis-opening-ceremony-with-mno-partners',
       details: [


### PR DESCRIPTION
## Summary
- reorder the Learn More accordion so Adiri content appears first and defaults open
- remove the Phase 1 and Phase 2 placeholder entries from the Adiri Phase 2 milestones tab

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de2fd250dc83249a8a3e80ddd2b6d9