### PR TITLE
Reorder learn more section and add Adiri phase timer icons

### DIFF
--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
-import HorizonLogoUrl from '@/assets/horizon.svg?url';
 import AdiriLogoUrl from '@/assets/adiri.svg?url';
 import type { Phase, Status } from '../data/statusSchema';
 import { ChevronIcon, ExternalLinkIcon, InfoIcon } from './icons';
@@ -138,11 +137,36 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
       (section) => !LEARN_MORE_PHASE_ORDER.includes(section.id)
     );
 
-    return [
+    const combinedSections = [
       ...sortedPhaseSections,
       ...remainingPhaseSections,
       ...ADDITIONAL_LEARN_MORE_SECTIONS,
     ];
+
+    const normalizeTitle = (title: string | undefined) =>
+      title?.trim().toLowerCase() ?? '';
+
+    const historyIndex = combinedSections.findIndex(
+      (section) => normalizeTitle(section.title) === 'history of the telcoin network',
+    );
+
+    if (historyIndex === -1) {
+      return combinedSections;
+    }
+
+    const [historySection] = combinedSections.splice(historyIndex, 1);
+    const regulationIndex = combinedSections.findIndex(
+      (section) => normalizeTitle(section.title) === 'regulation and compliance',
+    );
+
+    if (regulationIndex === -1) {
+      combinedSections.push(historySection);
+      return combinedSections;
+    }
+
+    combinedSections.splice(regulationIndex + 1, 0, historySection);
+
+    return combinedSections;
   }, [orderedSections]);
 
   const toggle = (id: string) => {
@@ -186,13 +210,11 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
           const isHistory = t === 'history of the telcoin network';
           const isAdiri = t === 'what is adiri';
           const isMainnet = t === 'what is mainnet';
-          const rowLogo = isHistory
-            ? { src: HorizonLogoUrl, alt: 'Horizon logo' }
-            : isAdiri
-              ? { src: AdiriLogoUrl, alt: 'Adiri logo' }
-              : isMainnet
-                ? { src: MAINNET_LOGO_URL, alt: 'Mainnet logo' }
-                : undefined;
+          const rowLogo = isAdiri
+            ? { src: AdiriLogoUrl, alt: 'Adiri logo' }
+            : isMainnet
+              ? { src: MAINNET_LOGO_URL, alt: 'Mainnet logo' }
+              : undefined;
           return (
             <article
               key={section.id}

--- a/src/components/MilestoneBlock.tsx
+++ b/src/components/MilestoneBlock.tsx
@@ -2,6 +2,7 @@ import type { PhaseKey } from '@/data/milestones';
 import { MILESTONES } from '@/data/milestones';
 import { roadToMainnetId } from '@/utils/ids';
 import CheckIconUrl from '/IMG/Checkmark.svg?url';
+import { TimerIcon } from './icons';
 
 type Props = { phase: PhaseKey };
 
@@ -67,26 +68,34 @@ export default function MilestoneBlock({ phase }: Props) {
           <span>Milestones</span>
         </div>
         <div className="mt-3 space-y-4">
-          {ADIRI_PHASE_GROUPS.map((group) => (
-            <div key={group.title}>
-              <h4 className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">{group.title}</h4>
-              <ul className="mt-2 space-y-2">
-                {group.items.map((item) => {
-                  const targetPhase = item.targetPhase ?? phase;
-                  const targetId = roadToMainnetId(targetPhase, item.slug);
-                  const href = `#${targetId}`;
-                  return (
-                    <li key={item.slug} className="flex items-start gap-3">
-                      <span className="mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full bg-white/50" />
-                      <a href={href} className="text-sm leading-6 text-white/90 hover:underline">
-                        {item.text}
-                      </a>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          ))}
+          {ADIRI_PHASE_GROUPS.map((group) => {
+            const isPhaseOne = group.title.trim().toLowerCase() === 'phase 1';
+
+            return (
+              <div key={group.title}>
+                <h4 className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">{group.title}</h4>
+                <ul className="mt-2 space-y-2">
+                  {group.items.map((item) => {
+                    const targetPhase = item.targetPhase ?? phase;
+                    const targetId = roadToMainnetId(targetPhase, item.slug);
+                    const href = `#${targetId}`;
+                    return (
+                      <li key={item.slug} className="flex items-start gap-3">
+                        {isPhaseOne ? (
+                          <TimerIcon className="mt-0.5 h-4 w-4 shrink-0 text-white/80" />
+                        ) : (
+                          <span className="mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full bg-white/50" />
+                        )}
+                        <a href={href} className="text-sm leading-6 text-white/90 hover:underline">
+                          {item.text}
+                        </a>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            );
+          })}
         </div>
       </div>
     );

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -205,6 +205,27 @@ export function TimelineIcon({ className, ...props }: IconProps) {
   );
 }
 
+export function TimerIcon({ className, ...props }: IconProps) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={`${baseClasses} ${className ?? ''}`}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      {...props}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M10 2h4" />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 6a8 8 0 108 8h0a8 8 0 10-8-8zm0 4v4l2.5 2.5"
+      />
+    </svg>
+  );
+}
+
 export function InfoIcon({ className, ...props }: IconProps) {
   return (
     <svg


### PR DESCRIPTION
## Summary
- move the History of the Telcoin Network accordion so it appears after Regulation and Compliance in the Learn more section and reuse the info icon there
- add a reusable timer icon and swap the Adiri Phase 1 milestone bullets for the new in-progress iconography

## Testing
- npm run lint *(fails: pre-existing lint errors in PasswordGate.tsx and useEqualizeMinHeight.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68de33c8569083248b39e3fcb5a9c97e