### PR TITLE
Replace Horizon references with Adiri

### DIFF
--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -30,7 +30,7 @@ const LEARN_MORE_CONTENT: Record<Phase['key'], { title: string; body: string[] }
     title: 'What is Adiri',
     body: [
       'Adiri is Telcoin Network’s public testnet, where the community and partners including mobile network operators (MNOs) spinning up validator nodes can interact with the network in a live but non-production setting.',
-      'This stage follows Horizon stabilization and will roll out in phases. Early iterations of Adiri may still see instability or bugs as the network undergoes continuous upgrades and audit cycles. That’s intentional: Adiri is where real-world testing happens, and where we make sure validator participation, governance mechanics, and protocol updates all function securely before moving to mainnet.',
+      'This stage follows Adiri stabilization and will roll out in phases. Early iterations of Adiri may still see instability or bugs as the network undergoes continuous upgrades and audit cycles. That’s intentional: Adiri is where real-world testing happens, and where we make sure validator participation, governance mechanics, and protocol updates all function securely before moving to mainnet.',
       'Adiri represents a critical milestone because it’s the first time the broader ecosystem validators, developers, and community members can meaningfully engage with Telcoin Network.',
     ],
   },
@@ -39,7 +39,7 @@ const LEARN_MORE_CONTENT: Record<Phase['key'], { title: string; body: string[] }
     body: [
       'Mainnet represents the full launch of Telcoin Network the moment we transition from testing to production and deliver a live, fully operational Layer 1 blockchain.ale operation. Together, these phases deliver the security and decentralization guarantees expected of a Layer 1 blockchain.',
       'This is where everything becomes real. Mainnet will use actual Telcoin (TEL) as its native currency, enabling genuine value transfer, real economic activity, and production-ready application deployment. Unlike the testing phases, every transaction, every smart contract, and every piece of value on Mainnet will have real-world significance.',
-      'Mainnet is the culmination of all our development efforts the secure, decentralized network that validators, developers, and users can trust for critical operations. After proving our technology through rigorous testing on Horizon and Adiri, Mainnet represents our commitment to delivering the security, performance, and decentralization guarantees expected of a world-class L1 blockchain.',
+      'Mainnet is the culmination of all our development efforts the secure, decentralized network that validators, developers, and users can trust for critical operations. After proving our technology through rigorous testing across Adiri environments, Mainnet represents our commitment to delivering the security, performance, and decentralization guarantees expected of a world-class L1 blockchain.',
       'For the Telcoin community, Mainnet launch marks a pivotal milestone: the transformation of years of development into a live network that will power the future of accessible financial services. This is when Telcoin Network stops being a promise and becomes a standard.',
     ],
   },

--- a/src/components/MilestoneBlock.tsx
+++ b/src/components/MilestoneBlock.tsx
@@ -26,8 +26,8 @@ const ADIRI_PHASE_GROUPS: AdiriPhaseGroup[] = [
         targetPhase: 'horizon',
       },
       {
-        text: 'Stabilize Horizon Environment',
-        slug: 'stabilize-horizon-environment',
+        text: 'Stabilize Adiri Environment',
+        slug: 'stabilize-adiri-environment',
         targetPhase: 'horizon',
       },
       {

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -44,7 +44,7 @@ const ADIRI_ACTIVE_BADGE: {
 };
 
 const PHASE_LOGOS: Partial<Record<Phase['key'], { src: string; alt: string }>> = {
-  devnet: { src: HorizonLogoUrl, alt: 'Horizon logo' },
+  devnet: { src: HorizonLogoUrl, alt: 'Adiri logo' },
   testnet: { src: AdiriLogoUrl, alt: 'Adiri logo' },
   mainnet: { src: '/IMG/Mainnet.svg', alt: 'Mainnet Logo' }
 };

--- a/src/components/RoadToDeployment/Flow.tsx
+++ b/src/components/RoadToDeployment/Flow.tsx
@@ -218,7 +218,7 @@ export function RoadToDeploymentFlow({ onSelectPhase }: FlowProps) {
               Road to deployment
             </h2>
             <p className="max-w-2xl text-sm text-fg-muted">
-              Follow how Genesis, Horizon, and Zenith flow from critical fixes into live deployment.
+              Follow how Genesis, Adiri, and Zenith flow from critical fixes into live deployment.
             </p>
           </div>
           <div className="max-w-xs rounded-2xl border-2 border-border bg-card p-4 shadow-glow">

--- a/src/data/milestones.ts
+++ b/src/data/milestones.ts
@@ -21,8 +21,8 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
       ],
     },
     {
-      text: 'Stabilize Horizon Environment',
-      slug: 'stabilize-horizon-environment',
+      text: 'Stabilize Adiri Environment',
+      slug: 'stabilize-adiri-environment',
       details: [
         'Deploy public devnet nodes',
         'Reset telscan.io',

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -25,18 +25,18 @@ export const ROADMAP: Phase[] = [
     title: 'Relaunch Genesis',
     subtitle: 'Devnet relaunch',
     status: 'up_next',
-    description: 'Stabilize Genesis to unblock Horizon relaunch.',
+    description: 'Stabilize Genesis to unblock Adiri relaunch.',
     dependsOn: ['fixes'],
     links: [{ label: 'See Genesis readiness', href: '#learn-more-devnet' }]
   },
   {
     id: 'horizon',
-    title: 'Launch Horizon',
+    title: 'Launch Adiri',
     subtitle: 'Public Testnet',
     status: 'planned',
     description: 'Early iterations guarded; audits complete.',
     dependsOn: ['genesis'],
-    links: [{ label: 'Review Horizon plan', href: '#learn-more-testnet' }]
+    links: [{ label: 'Review Adiri plan', href: '#learn-more-testnet' }]
   },
   {
     id: 'audits',

--- a/src/utils/__tests__/formatList.test.ts
+++ b/src/utils/__tests__/formatList.test.ts
@@ -11,11 +11,11 @@ describe('formatList', () => {
   });
 
   it('joins two items with and', () => {
-    expect(formatList(['Genesis', 'Horizon'])).toBe('Genesis and Horizon');
+    expect(formatList(['Genesis', 'Adiri'])).toBe('Genesis and Adiri');
   });
 
   it('joins more than two items with commas and and', () => {
-    expect(formatList(['Genesis', 'Horizon', 'Zeinith'])).toBe('Genesis, Horizon, and Zeinith');
+    expect(formatList(['Genesis', 'Adiri', 'Zeinith'])).toBe('Genesis, Adiri, and Zeinith');
   });
 
   it('ignores blank strings', () => {

--- a/status.json
+++ b/status.json
@@ -3,9 +3,9 @@
   "phases": [
     {
       "key": "devnet",
-      "title": "Horizon",
+      "title": "Adiri",
       "status": "in_progress",
-      "summary": "Finalizing high-priority security fixes and validating the Horizon development environment ahead of broader testing."
+      "summary": "Finalizing high-priority security fixes and validating the Adiri development environment ahead of broader testing."
     },
     {
       "key": "testnet",
@@ -32,7 +32,7 @@
   },
   "roadmap": [
     { "title": "Patch public vulnerabilities", "state": "in_progress" },
-    { "title": "Stabilize Horizon environment", "state": "up_next" },
+    { "title": "Stabilize Adiri environment", "state": "up_next" },
     { "title": "Open Adiri public testnet", "state": "planned" },
     {
       "title": "Address remaining findings from security competition",


### PR DESCRIPTION
## Summary
- update roadmap status, milestone, and learn more copy to refer to Adiri instead of Horizon
- adjust supporting data, UI text, and tests to reflect the Adiri naming

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68de3732ea9c8324bad179f2942e178c