### PR TITLE
Improve hero responsiveness on small screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,16 +77,16 @@ export default function App() {
             >
               <div className="flex flex-wrap items-start gap-6 md:flex-nowrap md:justify-between">
                 <div className="flex min-w-0 flex-1 flex-col gap-4">
-                  <div className="flex min-w-0 items-start gap-4">
+                  <div className="flex min-w-0 flex-col items-start gap-4 sm:flex-row">
                     <a
                       href="/"
                       onClick={onHome}
                       aria-label="Telcoin Roadmap home"
                       className="flex shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                     >
-                      <TelcoinAnimatedLogo className="h-28 w-28 shrink-0 md:h-32 md:w-32" />
+                      <TelcoinAnimatedLogo className="h-24 w-24 shrink-0 sm:h-28 sm:w-28 md:h-32 md:w-32" />
                     </a>
-                    <div className="min-w-[220px] flex-1 text-left">
+                    <div className="min-w-0 flex-1 text-left sm:min-w-[220px]">
                       <a
                         href="/"
                         onClick={onHome}


### PR DESCRIPTION
## Summary
- stack the hero logo and headline vertically on the smallest viewports
- reduce the base Telcoin logo footprint and gate larger sizing behind breakpoints
- allow the hero text block to shrink below 220px except on small screens and above

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de3e98ed1c8324a7eb158d4a7639c5