### PR TITLE
Update Road to Mainnet mainnet tab content and phase overview links

### DIFF
--- a/src/components/MilestoneBlock.tsx
+++ b/src/components/MilestoneBlock.tsx
@@ -9,6 +9,7 @@ type Props = { phase: PhaseKey };
 type AdiriPhaseGroup = {
   title: string;
   icon: 'check' | 'timer';
+  href: string;
   items: {
     text: string;
     slug: string;
@@ -21,6 +22,7 @@ const ADIRI_PHASE_GROUPS: AdiriPhaseGroup[] = [
   {
     title: 'Phase 1',
     icon: 'check',
+    href: '#road-to-mainnet-horizon-tab',
     items: [
       {
         text: 'Pre cantina competition',
@@ -51,6 +53,7 @@ const ADIRI_PHASE_GROUPS: AdiriPhaseGroup[] = [
   {
     title: 'Phase 2',
     icon: 'timer',
+    href: '#road-to-mainnet-adiri-tab',
     items: [
       {
         text: 'Patch security findings',
@@ -77,6 +80,7 @@ const ADIRI_PHASE_GROUPS: AdiriPhaseGroup[] = [
   {
     title: 'Phase 3',
     icon: 'timer',
+    href: '#road-to-mainnet-adiri-phase-3-tab',
     items: [
       {
         text: 'Integrate Adiri testnet with bridge solution',
@@ -110,12 +114,16 @@ export default function MilestoneBlock({ phase }: Props) {
           {ADIRI_PHASE_GROUPS.map((group) => {
             return (
               <div key={group.title}>
-                <h4 className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">{group.title}</h4>
+                <h4 className="text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
+                  <a
+                    href={group.href}
+                    className="inline-flex items-center gap-1 text-current transition hover:text-white/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                  >
+                    {group.title}
+                  </a>
+                </h4>
                 <ul className="mt-2 space-y-2">
                   {group.items.map((item) => {
-                    const targetPhase = item.targetPhase ?? phase;
-                    const targetId = roadToMainnetId(targetPhase, item.slug);
-                    const href = `#${targetId}`;
                     return (
                       <li key={item.slug} className="flex items-start gap-3">
                         {group.icon === 'check' ? (
@@ -125,9 +133,7 @@ export default function MilestoneBlock({ phase }: Props) {
                         ) : (
                           <span className="mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full bg-white/50" />
                         )}
-                        <a href={href} className="text-sm leading-6 text-white/90 hover:underline">
-                          {item.text}
-                        </a>
+                        <span className="text-sm leading-6 text-white/90">{item.text}</span>
                       </li>
                     );
                   })}

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -55,15 +55,6 @@ const PHASE_TO_DROPDOWN_KEY: Record<Phase['key'], PhaseKey> = {
   mainnet: 'mainnet'
 };
 
-const PHASE_ANCHORS: Partial<Record<Phase['key'], { href: string; ariaLabel: string }>> = {
-  devnet: {
-    href: '#history-of-the-telcoin-network',
-    ariaLabel: 'Jump to History of the Telcoin Network'
-  },
-  testnet: { href: '#what-is-adiri', ariaLabel: 'Jump to What is Adiri' },
-  mainnet: { href: '#what-is-mainnet', ariaLabel: 'Jump to What is Mainnet' }
-};
-
 type PhaseOverviewProps = {
   phases: Phase[];
 };
@@ -113,8 +104,6 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
               : STATUS_LABELS[phase.status];
           const Icon = NetworkIcon;
           const logo = PHASE_LOGOS[phase.key];
-          const anchor = PHASE_ANCHORS[phase.key];
-
           const subtitle = 'Release';
           const milestonePhaseKey = PHASE_TO_DROPDOWN_KEY[phase.key];
           const dataPhase = milestonePhaseKey;
@@ -170,27 +159,6 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
               </div>
             </div>
           );
-
-          if (anchor) {
-            return (
-              <div key={phase.key} className="h-full">
-                <a
-                  href={anchor.href}
-                  aria-label={anchor.ariaLabel}
-                  className="group block h-full focus:outline-none"
-                >
-                  <motion.article
-                    data-phase-card=""
-                    data-phase={dataPhase}
-                    className="flex h-full flex-col overflow-hidden rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] p-6 shadow-soft backdrop-blur transition hover:-translate-y-1 hover:shadow-glow"
-                    whileHover={{ y: -8 }}
-                  >
-                    {cardInner}
-                  </motion.article>
-                </a>
-              </div>
-            );
-          }
 
           return (
             <div key={phase.key} className="h-full">

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -18,6 +18,15 @@ const SHARED_ADIRI_PHASE_3_ITEMS: CustomItem[] = [
 
 const ADIRI_PHASE_3_ITEMS: CustomItem[] = SHARED_ADIRI_PHASE_3_ITEMS;
 
+const MAINNET_PHASE_ITEMS: CustomItem[] = [
+  { text: 'Cryptography security assessment', slug: 'cryptography-security-assessment' },
+  { text: 'P2P Network security assessment', slug: 'p2p-network-security-assessment' },
+  { text: 'Smart contract security assessments', slug: 'smart-contract-security-assessments' },
+  { text: 'Execution layer security assessment', slug: 'execution-layer-security-assessment' },
+  { text: 'State synchronization security assessment', slug: 'state-synchronization-security-assessment' },
+  { text: 'Patch security findings', slug: 'patch-security-findings' },
+];
+
 const HISTORY_ITEMS: CustomItem[] = SHARED_ADIRI_PHASE_3_ITEMS.map((item) => ({
   ...item,
   slug: `history-${item.slug}`,
@@ -36,8 +45,7 @@ const TABS: { key: TabKey; label: string }[] = [
 
 const isTabKey = (value: string): value is TabKey => TABS.some((tab) => tab.key === value);
 
-const isPhaseKey = (value: TabKey): value is PhaseKey =>
-  value === 'horizon' || value === 'adiri' || value === 'mainnet';
+const isPhaseKey = (value: TabKey): value is 'horizon' | 'adiri' => value === 'horizon' || value === 'adiri';
 
 export default function RoadToMainnet() {
   const [tab, setTab] = useState<TabKey>('horizon');
@@ -289,7 +297,10 @@ export default function RoadToMainnet() {
         </div>
       </div>
 
-      <div className="rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] p-6 shadow-soft backdrop-blur">
+      <div
+        id={`road-to-mainnet-${tab}-tab`}
+        className="rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] p-6 shadow-soft backdrop-blur"
+      >
         {/* Tabs */}
         <div className="mb-5 flex flex-wrap gap-2 rounded-xl bg-white/5 p-1 sm:inline-flex sm:flex-nowrap sm:gap-1">
           {TABS.map(({ key, label }) => (
@@ -314,6 +325,20 @@ export default function RoadToMainnet() {
           ) : tab === 'adiri-phase-3' ? (
             <ul className="space-y-4">
               {ADIRI_PHASE_3_ITEMS.map((item) => (
+                <li key={item.slug} className="flex items-start gap-3">
+                  <img
+                    src="/IMG/Loading.svg"
+                    alt=""
+                    aria-hidden="true"
+                    className="mt-0.5 h-5 w-5 shrink-0"
+                  />
+                  <span className="text-sm font-semibold text-white/90">{item.text}</span>
+                </li>
+              ))}
+            </ul>
+          ) : tab === 'mainnet' ? (
+            <ul className="space-y-4">
+              {MAINNET_PHASE_ITEMS.map((item) => (
                 <li key={item.slug} className="flex items-start gap-3">
                   <img
                     src="/IMG/Loading.svg"


### PR DESCRIPTION
## Summary
- replace the Road to Mainnet Mainnet tab with security assessment tasks displayed with the loading indicator
- ensure each tab panel exposes an anchor so phase overview cards can deep link into the Road to Mainnet tabs
- remove legacy card hyperlinks and retarget the Phase Overview section’s phase headings to the relevant Road to Mainnet tabs

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dea270a8b483249793fe1a18261251