### PR TITLE
Fix Road to Mainnet history tab and slow spinner speed

### DIFF
--- a/src/components/MilestoneBlock.tsx
+++ b/src/components/MilestoneBlock.tsx
@@ -135,7 +135,7 @@ export default function MilestoneBlock({ phase }: Props) {
                           <img
                             src={LoadingIconUrl}
                             alt=""
-                            className="mt-0.5 h-4 w-4 shrink-0 text-white/80 motion-safe:animate-spin"
+                            className="mt-0.5 h-4 w-4 shrink-0 text-white/80 motion-safe:animate-spin-slow"
                           />
                         ) : (
                           <span className="mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full bg-white/50" />
@@ -173,7 +173,7 @@ export default function MilestoneBlock({ phase }: Props) {
               <img
                 src={LoadingIconUrl}
                 alt=""
-                className="mt-0.5 h-4 w-4 shrink-0 motion-safe:animate-spin"
+                className="mt-0.5 h-4 w-4 shrink-0 motion-safe:animate-spin-slow"
               />
               <span className="text-sm leading-6 text-white/90">{text}</span>
             </li>

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -268,6 +268,8 @@ export default function RoadToMainnet() {
 
     return () => {
       cancelled = true;
+      mount.replaceChildren();
+      mount.textContent = '';
     };
   }, [tab]);
 
@@ -330,7 +332,7 @@ export default function RoadToMainnet() {
                     src="/IMG/Loading.svg"
                     alt=""
                     aria-hidden="true"
-                    className="mt-0.5 h-5 w-5 shrink-0"
+                    className="mt-0.5 h-5 w-5 shrink-0 motion-safe:animate-spin-slow"
                   />
                   <span className="text-sm font-semibold text-white/90">{item.text}</span>
                 </li>
@@ -344,7 +346,7 @@ export default function RoadToMainnet() {
                     src="/IMG/Loading.svg"
                     alt=""
                     aria-hidden="true"
-                    className="mt-0.5 h-5 w-5 shrink-0"
+                    className="mt-0.5 h-5 w-5 shrink-0 motion-safe:animate-spin-slow"
                   />
                   <span className="text-sm font-semibold text-white/90">{item.text}</span>
                 </li>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -37,7 +37,8 @@ const config: Config = {
       },
       animation: {
         progress: 'progress 1.4s ease-out forwards',
-        shimmer: 'shimmer 2.8s ease-in-out infinite'
+        shimmer: 'shimmer 2.8s ease-in-out infinite',
+        'spin-slow': 'spin 2.6s linear infinite'
       },
       ringColor: {
         DEFAULT: 'var(--ring)'


### PR DESCRIPTION
## Summary
- clear the injected issues feed when leaving the Track Issues tab so the History tab no longer shows that content
- introduce a slower spin animation and apply it to all loading icons across the roadmap components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dead6a4070832480ce4b32894357bc