### PR TITLE
Update Road to Mainnet completion indicators

### DIFF
--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -405,9 +405,19 @@ export default function RoadToMainnet() {
                 <li key={m.slug} id={roadToMainnetId(tab, m.slug)} className="scroll-mt-24">
                   <div className="text-sm font-semibold text-white/90">{m.text}</div>
                   {m.details && m.details.length > 0 && (
-                    <ul className="mt-2 list-disc pl-5 text-sm leading-6 text-white/80">
+                    <ul className="mt-2 space-y-3">
                       {m.details.map((detail, index) => (
-                        <li key={index}>{detail}</li>
+                        <li key={index} className="flex items-start gap-3">
+                          <img
+                            src={tab === 'horizon' ? '/IMG/Checkmark.svg' : '/IMG/Loading.svg'}
+                            alt=""
+                            aria-hidden="true"
+                            className={`mt-0.5 h-5 w-5 shrink-0${
+                              tab === 'adiri' ? ' motion-safe:animate-spin-slow' : ''
+                            }`}
+                          />
+                          <span className="text-sm leading-6 text-white/80">{detail}</span>
+                        </li>
                       ))}
                     </ul>
                   )}

--- a/src/data/milestones.ts
+++ b/src/data/milestones.ts
@@ -13,6 +13,7 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
   horizon: [
     {
       text: 'Pre-Cantina Competition',
+      done: true,
       slug: 'pre-cantina-competition',
       details: [
         'Preparation phase to finalize core components and stabilize the network ahead of the open security competition run by Cantina.',
@@ -20,6 +21,7 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
     },
     {
       text: 'Initial Spin-Up of TAO-Controlled Validator Nodes',
+      done: true,
       slug: 'initial-spin-up-of-tao-controlled-validator-nodes',
       details: [
         'Deployment of the first validator set operated by the Telcoin Autonomous Organization (TAO) to secure and coordinate early network operations.',
@@ -27,6 +29,7 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
     },
     {
       text: 'Launch Block Explorer',
+      done: true,
       slug: 'launch-block-explorer',
       details: [
         'Public release of a Telcoin Network block explorer, enabling developers and the community to view blocks, transactions, and validator activity transparently.',
@@ -34,6 +37,7 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
     },
     {
       text: 'Demo PoC',
+      done: true,
       slug: 'demo-poc',
       details: [
         'Demonstration of a proof-of-concept application to showcase the network’s functionality and real-world use cases.',
@@ -41,6 +45,7 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
     },
     {
       text: 'Feature Complete',
+      done: true,
       slug: 'feature-complete',
       details: [
         'Reaching the point where all planned core features are implemented and the network is functionally ready for audit and testing.',
@@ -48,6 +53,7 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
     },
     {
       text: '4-Week Security Assessment',
+      done: true,
       slug: '4-week-security-assessment',
       details: [
         'A dedicated month-long review involving audits, penetration testing, and vulnerability assessment to identify and resolve security issues before Mainnet launch.',


### PR DESCRIPTION
## Summary
- mark all Road to Mainnet phase 1 milestones as complete so they render with check icons
- swap the phase 1 detail bullets for checkmarks and phase 2 details for a loading spinner icon to highlight progress status

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec08834b8832481664721faa2cf48