### PR TITLE
Add faucet service milestone and update wiki link

### DIFF
--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -177,7 +177,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
     { label: 'Governance Forum', href: links.governanceForum },
     { label: 'Docs', href: links.technicalDocs },
     { label: 'Adiri RPC', href: 'https://chainlist.org/chain/2017' },
-    { label: 'Track Issues', href: 'https://github.com/Telcoin-Association/telcoin-network/issues' },
+    { label: 'Wiki', href: 'https://deepwiki.com/Telcoin-Association/telcoin-network' },
     { label: 'Telcoin Association', href: 'https://www.telcoin.org/' },
     { label: 'Twitter', href: 'https://x.com/TelcoinTAO' },
   ];

--- a/src/components/MilestoneBlock.tsx
+++ b/src/components/MilestoneBlock.tsx
@@ -73,6 +73,10 @@ const ADIRI_PHASE_GROUPS: AdiriPhaseGroup[] = [
         slug: 'improve-documentation',
       },
       {
+        text: 'Deploy new faucet service',
+        slug: 'deploy-new-faucet-service',
+      },
+      {
         text: 'Relaunch network',
         slug: 'relaunch-network',
       },

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -7,7 +7,11 @@ type ProgressBarProps = {
 };
 
 export function ProgressBar({ value, label }: ProgressBarProps) {
-  const clampedValue = useMemo(() => Math.min(100, Math.max(0, Math.round(value))), [value]);
+  const clampedValue = useMemo(() => {
+    const normalizedValue = Number.isFinite(value) ? value : 0;
+    const boundedValue = Math.min(100, Math.max(0, normalizedValue));
+    return Number.parseFloat(boundedValue.toFixed(2));
+  }, [value]);
   const reduceMotion = useReducedMotion();
   const style = useMemo(
     () => ({

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -52,7 +52,7 @@ const TABS: { key: TabKey; label: string }[] = [
   { key: 'adiri', label: 'Adiri Phase 2' },
   { key: 'adiri-phase-3', label: 'Adiri Phase 3' },
   { key: 'mainnet', label: 'Mainnet' },
-  { key: 'issues', label: 'Track Issues' },
+  { key: 'issues', label: 'Wiki' },
   { key: 'history', label: 'History' }
 ];
 
@@ -160,9 +160,9 @@ export default function RoadToMainnet() {
           return;
         }
 
-        console.log('[Track Issues] raw roadmap.json:', raw);
+        console.log('[Wiki feed] raw roadmap.json:', raw);
         const list = normalize(raw);
-        console.log('[Track Issues] normalized issues:', list);
+        console.log('[Wiki feed] normalized issues:', list);
 
         if (!list.length) {
           mount.innerHTML = "<div style='opacity:.7'>No open issues.</div>";
@@ -319,7 +319,7 @@ export default function RoadToMainnet() {
         className="rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] p-6 shadow-soft backdrop-blur"
       >
         {/* Tabs */}
-        <div className="mb-5 flex flex-wrap gap-2 rounded-xl bg-white/5 p-1 sm:inline-flex sm:flex-nowrap sm:gap-1">
+        <div className="mb-5 flex flex-wrap justify-center gap-2 rounded-xl bg-white/5 p-1 sm:mx-auto sm:inline-flex sm:flex-nowrap sm:justify-center sm:gap-1">
           {TABS.map(({ key, label }) => (
             <button
               key={key}

--- a/src/components/SecurityAudits.tsx
+++ b/src/components/SecurityAudits.tsx
@@ -90,7 +90,7 @@ export function SecurityAudits({ notes, publicFindings, afterPriorityFixes }: Se
         </article>
         <div className="flex flex-col gap-4">
           <StatCard
-            title="Public-Facing Vulnerabilities"
+            title="Priority Security Patches"
             description="Security issues reachable through public APIs, apps, or network endpoints."
             metrics={publicFindings}
             icon={
@@ -103,7 +103,7 @@ export function SecurityAudits({ notes, publicFindings, afterPriorityFixes }: Se
             }
           />
           <StatCard
-            title="Internal Security Findings"
+            title="Remaining Security Patches"
             description="Issues relevant to validator peers and internal infrastructure, prioritized after public-facing fixes."
             metrics={afterPriorityFixes}
             icon={

--- a/src/data/milestones.ts
+++ b/src/data/milestones.ts
@@ -90,6 +90,13 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
       ],
     },
     {
+      text: 'Deploy new faucet service',
+      slug: 'deploy-new-faucet-service',
+      details: [
+        'Launch a public faucet that distributes small amounts of testnet TEL, allowing developers and community members to easily access tokens for testing applications and transactions on the network.',
+      ],
+    },
+    {
       text: 'Relaunch Network',
       slug: 'relaunch-network',
       details: [

--- a/status.json
+++ b/status.json
@@ -1,5 +1,5 @@
 {
-  "meta": { "lastUpdated": "2025-09-23T19:00:00Z", "overallTrajectoryPct": 60 },
+  "meta": { "lastUpdated": "2025-09-23T19:00:00Z", "overallTrajectoryPct": 63.16 },
   "phases": [
     {
       "key": "devnet",


### PR DESCRIPTION
## Summary
- increase the roadmap header progress value to 63.16% and allow the progress bar to respect decimal percentages
- add the "Deploy new faucet service" milestone content across Phase 2 and Road to Mainnet while renaming the security patch cards
- center the Road to Mainnet tabs and replace the Track Issues navigation/button with the Telcoin Network wiki link

## Testing
- npm run lint *(fails: existing lint errors in RoadToDeployment Flow, useEqualizeMinHeight, and PasswordGate)*

------
https://chatgpt.com/codex/tasks/task_e_68dec5fc93cc8324bcde3467b5e0edf7