### PR TITLE
fix: use local Learn More logos

### DIFF
--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -17,18 +17,9 @@ type LearnMorePhaseSection = LearnMoreSection & { id: Phase['key'] };
 const LEARN_MORE_PHASE_ORDER: Phase['key'][] = ['testnet', 'mainnet', 'devnet'];
 
 const SECTION_LOGOS: Record<string, { src: string; alt: string }> = {
-  'enterprise-ready-platform': {
-    src: '/IMG/coming.svg',
-    alt: 'Enterprise Ready Platform logo',
-  },
-  'trust-and-security': {
-    src: '/IMG/security.svg',
-    alt: 'Trust and Security logo',
-  },
-  'regulation-and-compliance': {
-    src: '/IMG/compliance.svg',
-    alt: 'Regulation and Compliance logo',
-  },
+  'enterprise-ready-platform': { src: '/IMG/coming.svg', alt: 'Enterprise Ready Platform' },
+  'trust-and-security': { src: '/IMG/security.svg', alt: 'Trust and Security' },
+  'regulation-and-compliance': { src: '/IMG/compliance.svg', alt: 'Regulation and Compliance' },
 };
 
 const LEARN_MORE_CONTENT: Record<Phase['key'], { title: string; body: string[] }> = {
@@ -222,16 +213,15 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
       <div className="space-y-4">
         {sections.map((section) => {
           const isOpen = openId === section.id;
-          const t = section.title?.trim().toLowerCase();
-          const isHistory = t === 'history of the telcoin network';
-          const isAdiri = t === 'what is adiri';
-          const isMainnet = t === 'what is mainnet';
+          const isAdiri = section.id === 'testnet';
+          const isMainnet = section.id === 'mainnet';
+          const isHistory = section.id === 'devnet';
           const rowLogo = isAdiri
-            ? { src: AdiriLogoUrl, alt: 'Adiri logo' }
+            ? { src: AdiriLogoUrl, alt: 'Adiri' }
             : isMainnet
-              ? { src: MAINNET_LOGO_URL, alt: 'Mainnet logo' }
+              ? { src: MAINNET_LOGO_URL, alt: 'Mainnet' }
               : isHistory
-                ? { src: '/IMG/history.svg', alt: 'History of the Telcoin Network logo' }
+                ? { src: '/IMG/history.svg', alt: 'History of the Telcoin Network' }
                 : SECTION_LOGOS[section.id];
           return (
             <article


### PR DESCRIPTION
## Summary
- map extra Learn More sections to local IMG assets
- render phase logos by section id to use Adiri, Mainnet, and history icons reliably

## Testing
- npm run typecheck
- npm run build:nogate

------
https://chatgpt.com/codex/tasks/task_e_68decdb1813483308b4521c088b6df2c