### PR TITLE
Add critical severity badges to security patch summaries

### DIFF
--- a/src/components/SecurityAudits.tsx
+++ b/src/components/SecurityAudits.tsx
@@ -4,7 +4,10 @@ import type { Status } from '../data/statusSchema';
 
 type SecurityAuditsProps = Pick<Status['security'], 'notes' | 'publicFindings' | 'afterPriorityFixes'>;
 
+type SeverityMetrics = Status['security']['publicFindings'];
+
 const STAT_LABELS: Record<string, string> = {
+  critical: 'Critical',
   high: 'High',
   medium: 'Medium',
   low: 'Low',
@@ -19,10 +22,11 @@ function StatCard({
 }: {
   title: string;
   description?: string;
-  metrics: Record<string, number>;
+  metrics: SeverityMetrics;
   icon: ReactNode;
 }) {
-  const entries = Object.entries(metrics);
+  const { critical, ...remainingMetrics } = metrics;
+  const entries = Object.entries(remainingMetrics);
   return (
     <article className="flex flex-1 flex-col gap-4 rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] p-5 shadow-soft backdrop-blur">
       <header className="flex items-start gap-3">
@@ -36,6 +40,11 @@ function StatCard({
           ) : null}
         </div>
       </header>
+      {typeof critical === 'number' ? (
+        <span className="inline-block w-fit rounded-md bg-red-600 px-3 py-1 text-xs font-semibold text-white">
+          {STAT_LABELS.critical}: {critical}
+        </span>
+      ) : null}
       <dl className="grid grid-cols-2 gap-4 text-sm">
         {entries.map(([key, value]) => (
           <div key={key} className="flex flex-col rounded-xl border border-white/10 bg-white/5 p-3 text-fg backdrop-blur">

--- a/src/data/statusSchema.ts
+++ b/src/data/statusSchema.ts
@@ -32,12 +32,14 @@ export const statusSchema = z.object({
   security: z.object({
     notes: z.array(z.string().min(1)).nonempty(),
     publicFindings: z.object({
+      critical: nonNegativeInt,
       high: nonNegativeInt,
       medium: nonNegativeInt,
       low: nonNegativeInt,
       info: nonNegativeInt,
     }),
     afterPriorityFixes: z.object({
+      critical: nonNegativeInt,
       high: nonNegativeInt,
       medium: nonNegativeInt,
       low: nonNegativeInt,

--- a/status.json
+++ b/status.json
@@ -27,8 +27,8 @@
       "Next: focused security assessments (p2p network, key management, execution layer)",
       "Track issues on GitHub"
     ],
-    "publicFindings": { "high": 3, "medium": 2, "low": 5, "info": 4 },
-    "afterPriorityFixes": { "high": 0, "medium": 14, "low": 36, "info": 20 }
+    "publicFindings": { "critical": 0, "high": 3, "medium": 2, "low": 5, "info": 4 },
+    "afterPriorityFixes": { "critical": 0, "high": 0, "medium": 14, "low": 36, "info": 20 }
   },
   "roadmap": [
     { "title": "Patch public vulnerabilities", "state": "in_progress" },


### PR DESCRIPTION
## Summary
- add a prominent Critical severity badge to the priority and remaining security patch cards
- extend the security status schema and dataset with the new critical severity value

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ded44efbf8832482094a624e1def33