### PR TITLE
Disable default password gate

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,10 +11,16 @@ if (!rootElement) {
   throw new Error('Failed to find the root element');
 }
 
+const gateEnabled = import.meta.env.VITE_ENABLE_PASSWORD_GATE === '1';
+
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <PasswordGate>
+    {gateEnabled ? (
+      <PasswordGate>
+        <App />
+      </PasswordGate>
+    ) : (
       <App />
-    </PasswordGate>
+    )}
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- disable the password gate wrapper so the roadmap renders immediately
- keep the password gate component available behind an environment toggle for future use

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ded60390008330b1f9a06e5f1f44bf