### PR TITLE
Mark ADIRI Phase 3 items as done/in-progress; update milestones, developer notes, and status

### DIFF
--- a/src/components/MilestoneBlock.tsx
+++ b/src/components/MilestoneBlock.tsx
@@ -18,6 +18,8 @@ type AdiriPhaseGroup = {
   items: {
     text: string;
     slug: string;
+    inProgress?: boolean;
+    done?: boolean;
   }[];
 };
 
@@ -67,7 +69,7 @@ const ADIRI_PHASE_GROUPS: AdiriPhaseGroup[] = [
     title: 'Phase 3',
     icon: 'loading',
     href: '#road-to-mainnet-adiri-phase-3-tab',
-    items: ADIRI_PHASE_3_ITEMS.map(({ text, slug }) => ({ text, slug })),
+    items: ADIRI_PHASE_3_ITEMS.map(({ text, slug, inProgress, done }) => ({ text, slug, inProgress, done })),
   },
 ];
 
@@ -94,13 +96,22 @@ const ADIRI_MILESTONE_STATUS = new Map(
   ]),
 );
 
-const getAdiriItemStatus = (group: AdiriPhaseGroup, slug: string): MilestoneItemStatus => {
+const getAdiriItemStatus = (
+  group: AdiriPhaseGroup,
+  item: { slug: string; inProgress?: boolean; done?: boolean },
+): MilestoneItemStatus => {
   if (group.title === 'Phase 2') {
-    return ADIRI_MILESTONE_STATUS.get(slug) ?? 'queued';
+    return ADIRI_MILESTONE_STATUS.get(item.slug) ?? 'queued';
   }
 
-  if (group.title === 'Phase 3' && ACTIVE_PHASE_3_SLUGS.has(slug)) {
-    return 'in_progress';
+  if (group.title === 'Phase 3') {
+    if (item.done) {
+      return 'completed';
+    }
+
+    if (item.inProgress || ACTIVE_PHASE_3_SLUGS.has(item.slug)) {
+      return 'in_progress';
+    }
   }
 
   if (group.icon === 'check') {
@@ -123,8 +134,8 @@ export default function MilestoneBlock({ phase }: Props) {
           {ADIRI_PHASE_GROUPS.map((group) => {
             const isOpenByDefault = group.title === 'Phase 2' || group.title === 'Phase 3';
             const sortedItems = [...group.items].sort((a, b) => {
-              const aOrder = STATUS_SORT_ORDER[getAdiriItemStatus(group, a.slug)];
-              const bOrder = STATUS_SORT_ORDER[getAdiriItemStatus(group, b.slug)];
+              const aOrder = STATUS_SORT_ORDER[getAdiriItemStatus(group, a)];
+              const bOrder = STATUS_SORT_ORDER[getAdiriItemStatus(group, b)];
               return aOrder - bOrder;
             });
             return (
@@ -153,7 +164,7 @@ export default function MilestoneBlock({ phase }: Props) {
                   </a>
                   <ul className="mt-2 space-y-2">
                     {sortedItems.map((item) => {
-                      const itemStatus = getAdiriItemStatus(group, item.slug);
+                      const itemStatus = getAdiriItemStatus(group, item);
                       const isInProgress = itemStatus === 'in_progress';
                       const shouldAnimate = isInProgress && !reduceMotion;
 

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -7,7 +7,7 @@ import { ROAD_TO_MAINNET_SECTION_ID, roadToMainnetId } from '@/utils/ids';
 import { ExternalLinkIcon } from './icons';
 import ActivityIconUrl from '/IMG/activity.svg?url';
 
-type CustomItem = { text: string; slug: string; description?: string };
+type CustomItem = { text: string; slug: string; description?: string; inProgress?: boolean; done?: boolean };
 
 const SHARED_ADIRI_PHASE_3_ITEMS: CustomItem[] = [
   { text: 'MVP demonstrating EVM + BFT consensus', slug: 'mvp-demonstrating-evm-bft-consensus' },
@@ -33,10 +33,8 @@ const HISTORY_ITEMS: CustomItem[] = SHARED_ADIRI_PHASE_3_ITEMS.map((item) => ({
 }));
 
 const ACTIVE_PHASE_2_SLUGS = new Set<string>([
-  'production-harden-p2p-networking',
   'stress-test-deployed-network',
   'custom-tn-rpc-endpoints',
-  'support-multiple-workers-for-parallel-fee-markets',
   'tn-whitepaper',
 ]);
 
@@ -342,9 +340,12 @@ export default function RoadToMainnet() {
           ) : tab === 'adiri-phase-3' ? (
             <ul key="adiri-phase-3" className="space-y-4">
               {ADIRI_PHASE_3_ITEMS.map((item) => {
-                const isActivePhase3Milestone = ACTIVE_PHASE_3_SLUGS.has(item.slug);
+                const isDone = Boolean(item.done);
+                const isActivePhase3Milestone = ACTIVE_PHASE_3_SLUGS.has(item.slug) && !isDone;
                 const shouldAnimate = isActivePhase3Milestone && !reduceMotion;
-                const iconSrc = isActivePhase3Milestone
+                const iconSrc = isDone
+                  ? '/IMG/Checkmark.svg'
+                  : isActivePhase3Milestone
                   ? ActivityIconUrl
                   : '/IMG/Loading.svg';
 
@@ -370,7 +371,7 @@ export default function RoadToMainnet() {
                         alt=""
                         aria-hidden="true"
                         className={`mt-0.5 h-5 w-5 shrink-0${
-                          isActivePhase3Milestone ? '' : ' motion-safe:animate-spin-slow'
+                          isDone || isActivePhase3Milestone ? '' : ' motion-safe:animate-spin-slow'
                         }`}
                       />
                     )}

--- a/src/data/developerNotes.ts
+++ b/src/data/developerNotes.ts
@@ -50,11 +50,20 @@ const FEBRUARY_05_DEVELOPER_NOTES = [
 ];
 
 
+
+const APRIL_20_DEVELOPER_NOTES = [
+  "The team has nearly completed prioritized work on state-breaking changes including pre-compiles and execution-level protocol changes that would cause a fork if upgraded while the network is running. This work will lock in the network's core on-chain architecture.",
+  'Testnet will have a stable release soon with final deterministic changes, supporting over 7,000 validators (up from 1,100 cap), native ERC20 interface support, and production-ready database. The stable version is intended to last indefinitely.',
+  "A pre-compile extending the ERC20 interface to native token balances was implemented so users don't need to wrap TEL for DeFi transactions or dApp integration. The core consensus registry was also improved, increasing validator capacity from ~1,100 to over 7,000 validators.",
+  'AI-assisted security scans continue at $200 per month (compared to $50,000 per week for manual research), methodically working through isolated crates. Third-party human security assessments will follow as the last security gate before mainnet launch.',
+  'Testnet will run in parallel with mainnet indefinitely as a sandbox environment using identical code, tools, and data centers (only differing by chain IDs). This allows safe testing of updates before applying them to mainnet and gives developers a testing environment.',
+];
+
 const MARCH_13_DEVELOPER_NOTES = [
   'Closed 12 pull requests covering production hardening, bug fixes, and security improvements.',
   'Production hardening syncing strategy is complete and confirming specialist researcher availability with security partners is complete.',
   'Execution environment isolation has been completed to accelerate core protocol execution and readiness.',
-  'Support multiple workers for parallel fee markets and deploy new faucet service are now in progress.',
+  'Support multiple workers for parallel fee markets and deploy new faucet service are complete.',
   'TN Whitepaper drafting is now in progress.',
   'Database layer upgrades were completed and merged, clearing the way for testnet launch readiness activities.',
   'P2P streaming for bulk data transfer remains in final testing and nearing completion.',
@@ -66,17 +75,18 @@ const MARCH_13_DEVELOPER_NOTES = [
 ];
 
 const FEBRUARY_19_DEVELOPER_NOTES = [
-  'In Progress: Support P2P Streaming for Bulk Data Transfer — Implement peer-to-peer streaming mechanisms to enable efficient bulk data transfer between nodes, improving sync performance and reducing reliance on centralized distribution.',
+  'Done: Support P2P Streaming for Bulk Data Transfer — Implement peer-to-peer streaming mechanisms to enable efficient bulk data transfer between nodes, improving sync performance and reducing reliance on centralized distribution.',
   'In Progress: Streamline Database Infrastructure for Production — Refactor and optimise database architecture to ensure production-grade performance, reliability, and scalability across validators and observers.',
   'In Progress: Custom TN RPC Endpoints — Develop dedicated Telcoin Network RPC endpoints tailored to ecosystem use cases, improving performance, flexibility, and infrastructure control.',
   'In Progress: Harden Epoch Boundary Records for Secure Syncing — Improve validation and integrity checks around epoch boundary records to ensure secure, deterministic syncing across network participants.',
   'In Progress: Better Tools for Validators to Sync, Stake, and Activate — Enhance CLI tooling and workflows for validators to sync more efficiently, stake with clearer flows, and activate validators with improved reliability and UX.',
-  'To Do: Support Multiple Workers for Parallel Fee Markets — Enable validators to operate multiple workers to segregate transaction pools, allowing independent fee markets, use-case specific execution environments, and horizontal scalability without separate chains.',
+  'Done: Support Multiple Workers for Parallel Fee Markets — Enable validators to operate multiple workers to segregate transaction pools, allowing independent fee markets, use-case specific execution environments, and horizontal scalability without separate chains.',
   'Done: Updates to Support Open-Source Contributions — Implemented structural and workflow improvements to make the repository more accessible for external contributors, improving transparency and community participation.',
   'Done: Parallelize Testing Infrastructure — Refactored testing systems to run in parallel, significantly reducing CI times and increasing reliability of test coverage.',
 ];
 
 const developerNoteDates = [
+  '2026-04-20T00:00:00Z',
   '2026-03-29T00:00:00Z',
   '2026-02-19T00:00:00Z',
   '2026-02-05T00:00:00Z',
@@ -93,6 +103,11 @@ export const getLatestDeveloperNotesDate = () =>
   );
 
 export const buildDeveloperNoteSections = (recentNotes: string[]): DeveloperNoteSection[] => [
+  {
+    title: 'Developer Notes - Updated 20 April 2026',
+    date: '2026-04-20',
+    items: APRIL_20_DEVELOPER_NOTES,
+  },
   {
     title: 'Developer Notes - Updated 29 March 2026',
     date: '2026-03-29',

--- a/src/data/milestones.ts
+++ b/src/data/milestones.ts
@@ -15,6 +15,7 @@ export type CustomRoadToMainnetItem = {
   slug: string;
   description?: string;
   inProgress?: boolean;
+  done?: boolean;
 };
 
 export const ADIRI_PHASE_3_ITEMS: CustomRoadToMainnetItem[] = [
@@ -56,13 +57,14 @@ export const ADIRI_PHASE_3_ITEMS: CustomRoadToMainnetItem[] = [
   {
     text: 'Launch Community-Driven Testing Tools',
     slug: 'launch-community-driven-testing-tools',
-    inProgress: true,
+    done: true,
     description:
       'Release community-led testing tools and workflows so external contributors can validate network behavior and report regressions earlier.',
   },
   {
-    text: 'TODO: Improve Syncing Times for New Nodes',
+    text: 'Improve Syncing Times for New Nodes',
     slug: 'improve-syncing-times-for-new-nodes',
+    inProgress: true,
     description:
       'Further optimize initial node sync performance to reduce time-to-participation for new validators and observers.',
   },
@@ -146,7 +148,7 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
     },
     {
       text: 'Production Harden P2P Networking',
-      status: 'in_progress',
+      done: true,
       slug: 'production-harden-p2p-networking',
       details: [
         'Strengthen peer-to-peer networking for production readiness, including stability, efficiency, and abuse resistance improvements.',
@@ -258,7 +260,7 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
     },
     {
       text: 'Support Multiple Workers for Parallel Fee Markets',
-      status: 'in_progress',
+      done: true,
       slug: 'support-multiple-workers-for-parallel-fee-markets',
       details: [
         'Enable validators to operate multiple workers to segregate transaction pools for independent fee markets, use-case specific execution environments, and horizontal scalability without separate chains.',

--- a/status.json
+++ b/status.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "lastUpdated": "2026-03-29T00:00:00Z",
-    "overallTrajectoryPct": 90
+    "lastUpdated": "2026-04-20T00:00:00Z",
+    "overallTrajectoryPct": 93
   },
   "phases": [
     {
@@ -27,7 +27,8 @@
     "notes": [
       "TN Whitepaper drafting moved to in progress",
       "Develop new faucet service completed",
-      "Support multiple workers for parallel fee markets moved to in progress",
+      "Production harden P2P networking completed",
+      "Support multiple workers for parallel fee markets completed",
       "Execution environment isolation completed",
       "Confirmed availability of specialist security researchers with partners",
       "Production harden syncing strategy completed",


### PR DESCRIPTION
### Motivation
- Surface accurate per-item status for ADIRI Phase 3 so completed items render as completed and only active items animate as in-progress.
- Update milestone and developer note data to reflect recent progress and adjust global status metadata.

### Description
- Update MilestoneBlock UI to accept `inProgress` and `done` flags on items, change `getAdiriItemStatus` to use the new item shape, and sort/render items based on the computed status.
- Adjust RoadToMainnet to extend `CustomItem` with `inProgress`/`done` flags, show a check icon for `done` items, avoid spinning/animating completed items, and treat active Phase 3 slugs as not active when `done` is true.
- Modify `milestones.ts` to add `done`/`inProgress` markers for ADIRI Phase 3 items and flip several Phase 2 milestone statuses to `done` where appropriate.
- Add a new `APRIL_20_DEVELOPER_NOTES` section, include it in the developer notes list, and update `developerNoteDates` ordering.
- Bump `status.json` `lastUpdated` and `overallTrajectoryPct` and update security notes to reflect completed work.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e682b3b9d08330979e45999ada16cc)