### PR TITLE
Adiri Testnet Final Phase launch: hero card, visual polish, milestone updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { loadStatus, type Status } from './data/loadStatus';
 import { TelcoinAnimatedLogo } from './components/TelcoinAnimatedLogo';
 import LastUpdated from '@/components/LastUpdated';
 import { getLatestDeveloperNotesDate } from '@/data/developerNotes';
+import AdiriLogoUrl from '@/assets/adiri.svg?url';
 
 const sectionVariants = {
   hidden: { opacity: 0, y: 24 },
@@ -63,8 +64,9 @@ export default function App() {
   };
 
   return (
-    <div className="min-h-screen bg-bg bg-hero-ambient text-fg">
-      <header className="bg-card backdrop-blur">
+    <div className="relative min-h-screen bg-bg bg-hero-ambient text-fg">
+      <div className="pointer-events-none fixed inset-0 z-0 opacity-[0.025]" style={{ backgroundImage: 'url("data:image/svg+xml,%3Csvg viewBox=\'0 0 256 256\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cfilter id=\'n\'%3E%3CfeTurbulence type=\'fractalNoise\' baseFrequency=\'0.85\' numOctaves=\'4\' stitchTiles=\'stitch\'/%3E%3C/filter%3E%3Crect width=\'100%25\' height=\'100%25\' filter=\'url(%23n)\'/%3E%3C/svg%3E")', backgroundRepeat: 'repeat' }} />
+      <header className="relative bg-card backdrop-blur">
         <div className="mx-auto max-w-5xl px-6 py-16 md:px-8">
           {showSkeleton ? (
             <HeaderSkeleton />
@@ -93,7 +95,7 @@ export default function App() {
                         onClick={onHome}
                         className="block space-y-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
                       >
-                        <h1 className="text-2xl font-extrabold text-fg md:text-3xl">
+                        <h1 className="bg-gradient-to-r from-fg via-primary to-fg bg-clip-text text-2xl font-extrabold text-transparent md:text-3xl">
                           Telcoin Network Roadmap
                         </h1>
                         <p className="max-w-xl text-sm text-fg-muted md:text-base">
@@ -144,6 +146,7 @@ export default function App() {
             </motion.div>
           )}
         </div>
+        <div className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
       </header>
       <main
         className="mx-auto max-w-5xl space-y-16 px-6 py-16 md:px-8"
@@ -162,29 +165,66 @@ export default function App() {
           </>
         ) : (
           <>
+            <section className="px-6 md:px-8">
+              <motion.div
+                className="relative flex flex-col items-center gap-4 overflow-hidden rounded-[16px] border border-primary/40 bg-[#172552] px-6 py-6 shadow-[0_0_30px_rgba(25,200,255,0.12)] backdrop-blur md:px-10 md:py-8"
+                animate={{ boxShadow: ['0 0 30px rgba(25,200,255,0.12)', '0 0 40px rgba(25,200,255,0.22)', '0 0 30px rgba(25,200,255,0.12)'] }}
+                transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+              >
+                <div className="absolute inset-0 bg-gradient-to-r from-primary/5 via-transparent to-accent/5" />
+                <div className="relative flex items-center justify-center gap-4">
+                  <span className="inline-flex items-center rounded-full border border-success/40 bg-success/15 px-3 py-1 text-sm font-semibold text-success">
+                    Live
+                  </span>
+                  <p className="text-2xl font-bold text-fg md:text-3xl">
+                    Adiri Testnet Final Phase
+                  </p>
+                </div>
+                <p className="relative max-w-2xl text-center text-sm leading-relaxed text-fg-muted">
+                  Telcoin Network's Adiri testnet has launched as a stable network.
+                  This build – the final phase before mainnet – is ready for MNOs to onboard as validators and developers to build dApps.
+                </p>
+                <p className="relative text-center text-sm text-fg-muted">
+                  For developer access and support, contact{' '}
+                  <a href="mailto:devs@telcoin.org" className="text-primary hover:underline">
+                    devs@telcoin.org
+                  </a>
+                </p>
+              </motion.div>
+            </section>
+
             <section>
-              <PhaseOverview phases={status.phases} />
+              <div className="rounded-2xl border border-white/[0.06] bg-white/[0.04] p-6 backdrop-blur-sm md:p-8">
+                <PhaseOverview phases={status.phases} />
+              </div>
             </section>
 
             <section id="security-section">
-              <SecurityAudits
-                notes={status.security.notes}
-                publicFindings={status.security.publicFindings}
-                afterPriorityFixes={status.security.afterPriorityFixes}
-              />
+              <div className="rounded-2xl border border-white/[0.06] bg-white/[0.04] p-6 backdrop-blur-sm md:p-8">
+                <SecurityAudits
+                  notes={status.security.notes}
+                  publicFindings={status.security.publicFindings}
+                  afterPriorityFixes={status.security.afterPriorityFixes}
+                />
+              </div>
             </section>
 
             <section>
-              <RoadToMainnet />
+              <div className="rounded-2xl border border-white/[0.06] bg-white/[0.04] p-6 backdrop-blur-sm md:p-8">
+                <RoadToMainnet />
+              </div>
             </section>
 
             <section>
-              <LearnMore phases={status.phases} links={status.links} />
+              <div className="rounded-2xl border border-white/[0.06] bg-white/[0.04] p-6 backdrop-blur-sm md:p-8">
+                <LearnMore phases={status.phases} links={status.links} />
+              </div>
             </section>
           </>
         )}
       </main>
-      <footer className="border-t-2 border-border/60 bg-card py-8 text-center text-sm text-fg-muted backdrop-blur">
+      <footer className="relative bg-card py-8 text-center text-sm text-fg-muted backdrop-blur">
+        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/30 to-transparent" />
         © 2025{' '}
         <a href="https://www.telcoin.network/" className="text-primary hover:underline">
           Telcoin Network

--- a/src/components/LearnMore.tsx
+++ b/src/components/LearnMore.tsx
@@ -93,18 +93,8 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
     () => phases.map((phase) => ({ key: phase.key, status: phase.status })),
     [phases]
   );
-  const defaultOpenId = useMemo(() => {
-    const hasAdiri = orderedSections.some((section) => section.key === 'testnet');
-    if (hasAdiri) {
-      return 'testnet';
-    }
-
-    const activePhase = orderedSections.find(
-      (section) => section.status === 'in_progress'
-    );
-    return activePhase?.key ?? orderedSections[0]?.key ?? null;
-  }, [orderedSections]);
-  const [openId, setOpenId] = useState<string | null>(defaultOpenId);
+  const defaultOpenId = useMemo<string | null>(() => null, []);
+  const [openId, setOpenId] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -129,7 +119,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
           element.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
       } else {
-        setOpenId(defaultOpenId);
+        setOpenId(null);
       }
     };
 
@@ -255,7 +245,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
                       ? 'what-is-mainnet'
                       : `learn-more-${section.id}`
               }
-              className="overflow-hidden rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] shadow-soft backdrop-blur"
+              className="overflow-hidden rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] shadow-soft backdrop-blur transition-all duration-300 hover:border-primary/40 hover:shadow-glow"
             >
               <motion.button
                 type="button"
@@ -307,7 +297,7 @@ export function LearnMore({ phases, links }: LearnMoreProps) {
         {linkButtons.map((link) => (
           <motion.a
             key={link.label}
-            className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-fg shadow-soft backdrop-blur transition hover:-translate-y-0.5 hover:text-primary"
+            className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-fg shadow-soft backdrop-blur transition-all duration-300 hover:-translate-y-0.5 hover:text-primary hover:shadow-[0_4px_20px_rgba(25,200,255,0.15)]"
             href={link.href}
             target="_blank"
             rel="noreferrer noopener"

--- a/src/components/MilestoneBlock.tsx
+++ b/src/components/MilestoneBlock.tsx
@@ -61,7 +61,7 @@ const ADIRI_PHASE_GROUPS: AdiriPhaseGroup[] = [
   },
   {
     title: 'Phase 2',
-    icon: 'loading',
+    icon: 'check',
     href: '#road-to-mainnet-adiri-tab',
     items: MILESTONES.adiri.map(({ text, slug }) => ({ text, slug })),
   },
@@ -132,7 +132,7 @@ export default function MilestoneBlock({ phase }: Props) {
         </div>
         <div className="mt-3 space-y-4">
           {ADIRI_PHASE_GROUPS.map((group) => {
-            const isOpenByDefault = group.title === 'Phase 2' || group.title === 'Phase 3';
+            const isOpenByDefault = false;
             const sortedItems = [...group.items].sort((a, b) => {
               const aOrder = STATUS_SORT_ORDER[getAdiriItemStatus(group, a)];
               const bOrder = STATUS_SORT_ORDER[getAdiriItemStatus(group, b)];
@@ -148,11 +148,18 @@ export default function MilestoneBlock({ phase }: Props) {
                   <span className="text-xs font-semibold uppercase tracking-[0.2em] text-white/80">
                     {group.title}
                   </span>
-                  <span
-                    aria-hidden="true"
-                    className="text-sm text-white/60 transition-transform group-open/section:rotate-180"
-                  >
-                    ▾
+                  <span className="flex items-center gap-2">
+                    {group.icon === 'check' && (
+                      <span className="rounded-full border border-success/30 bg-success/10 px-2 py-0.5 text-[10px] font-semibold text-success">
+                        Complete
+                      </span>
+                    )}
+                    <span
+                      aria-hidden="true"
+                      className="text-sm text-white/60 transition-transform group-open/section:rotate-180"
+                    >
+                      ▾
+                    </span>
                   </span>
                 </summary>
                 <div className="px-3 pb-3">

--- a/src/components/PhaseOverview.tsx
+++ b/src/components/PhaseOverview.tsx
@@ -186,7 +186,7 @@ export function PhaseOverview({ phases }: PhaseOverviewProps) {
               <motion.article
                 data-phase-card=""
                 data-phase={dataPhase}
-                className="group flex h-full flex-col overflow-hidden rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] p-6 shadow-soft backdrop-blur transition hover:shadow-glow"
+                className="group flex h-full flex-col overflow-hidden rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] p-6 shadow-soft backdrop-blur transition-all duration-300 hover:border-primary/40 hover:shadow-glow"
               >
                 {cardInner}
               </motion.article>

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -37,7 +37,7 @@ export function ProgressBar({ value, label }: ProgressBarProps) {
         aria-valuemax={100}
       >
         <motion.div
-          className="relative h-full rounded-full bg-gradient-to-r from-primary via-accent to-primary-600 shadow-[0_6px_18px_rgba(59,130,246,0.25)]"
+          className="relative h-full overflow-hidden rounded-full bg-gradient-to-r from-primary via-accent to-primary-600 shadow-[0_6px_18px_rgba(59,130,246,0.25)] after:absolute after:inset-0 after:animate-shimmer after:bg-[linear-gradient(120deg,transparent_0%,rgba(255,255,255,0)_25%,rgba(255,255,255,0.3)_50%,rgba(255,255,255,0)_75%,transparent_100%)] motion-reduce:after:hidden"
           style={style}
           initial={{ width: 0, opacity: 1 }}
           animate={

--- a/src/components/RoadToMainnet.tsx
+++ b/src/components/RoadToMainnet.tsx
@@ -33,9 +33,7 @@ const HISTORY_ITEMS: CustomItem[] = SHARED_ADIRI_PHASE_3_ITEMS.map((item) => ({
 }));
 
 const ACTIVE_PHASE_2_SLUGS = new Set<string>([
-  'stress-test-deployed-network',
   'custom-tn-rpc-endpoints',
-  'tn-whitepaper',
 ]);
 
 const ACTIVE_PHASE_3_SLUGS = new Set<string>(

--- a/src/components/SecurityAudits.tsx
+++ b/src/components/SecurityAudits.tsx
@@ -33,7 +33,7 @@ function StatCard({
       ? ([['critical', critical], ...entries] as Array<[string, number]>)
       : entries;
   return (
-    <article className="flex flex-1 flex-col gap-4 rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] p-5 shadow-soft backdrop-blur">
+    <article className="flex flex-1 flex-col gap-4 rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] p-5 shadow-soft backdrop-blur transition-all duration-300 hover:border-primary/40 hover:shadow-glow">
       <header className="flex items-start gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/20 text-primary">
           {icon}
@@ -86,7 +86,7 @@ export function SecurityAudits({ notes, publicFindings, afterPriorityFixes }: Se
         </div>
       </div>
       <div className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
-        <article className="flex h-full flex-col rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] p-6 shadow-soft backdrop-blur">
+        <article className="flex h-full flex-col rounded-[16px] border-[0.4px] border-[#C9CFED99] bg-[#172552] p-6 shadow-soft backdrop-blur transition-all duration-300 hover:border-primary/40 hover:shadow-glow">
           <div className="flex-1">
             <h3 className="text-lg font-semibold text-fg">{currentSection.title}</h3>
             <ul className="mt-4 space-y-3 text-sm text-fg-muted">

--- a/src/data/developerNotes.ts
+++ b/src/data/developerNotes.ts
@@ -59,6 +59,15 @@ const APRIL_20_DEVELOPER_NOTES = [
   'Testnet will run in parallel with mainnet indefinitely as a sandbox environment using identical code, tools, and data centers (only differing by chain IDs). This allows safe testing of updates before applying them to mainnet and gives developers a testing environment.',
 ];
 
+const MAY_07_DEVELOPER_NOTES = [
+  'Adiri testnet has officially launched as a stable network — the final phase before mainnet. MNOs can now onboard as validators and developers can build dApps directly on the network.',
+  'Block explorer is live at telscan.io, powered by a new Nethereum-based deployment with full transaction routing support.',
+  'Faucet page restored with stablecoin drip support for developer onboarding.',
+  'Community-contributed test coverage expansion underway — targeting ~125 new tests across certifier, storage, and type crates with a structured harness approach.',
+  'DNS and infrastructure finalized for stable testnet deployment across MNO data center environments.',
+  'Testnet teardown and redeployment completed to establish the stable long-running network build.',
+];
+
 const APRIL_24_DEVELOPER_NOTES = [
   "Significant progress has been made on state-breaking changes and pre-compiles to lock in the network's core on-chain architecture.",
   'Validator capacity has increased dramatically from approximately 1,100 to over 7,000.',
@@ -96,6 +105,7 @@ const FEBRUARY_19_DEVELOPER_NOTES = [
 ];
 
 const developerNoteDates = [
+  '2026-05-07T00:00:00Z',
   '2026-04-24T00:00:00Z',
   '2026-04-20T00:00:00Z',
   '2026-03-29T00:00:00Z',
@@ -114,6 +124,11 @@ export const getLatestDeveloperNotesDate = () =>
   );
 
 export const buildDeveloperNoteSections = (recentNotes: string[]): DeveloperNoteSection[] => [
+  {
+    title: 'Developer Notes - Updated 7 May 2026',
+    date: '2026-05-07',
+    items: MAY_07_DEVELOPER_NOTES,
+  },
   {
     title: 'Developer Notes - Updated 24 April 2026',
     date: '2026-04-24',

--- a/src/data/milestones.ts
+++ b/src/data/milestones.ts
@@ -20,6 +20,13 @@ export type CustomRoadToMainnetItem = {
 
 export const ADIRI_PHASE_3_ITEMS: CustomRoadToMainnetItem[] = [
   {
+    text: 'TN Whitepaper',
+    slug: 'tn-whitepaper',
+    inProgress: true,
+    description:
+      'Drafting and reviewing the Telcoin Network whitepaper to consolidate technical architecture, governance model, and ecosystem positioning for external stakeholders.',
+  },
+  {
     text: 'Integrate Adiri Testnet with Bridge Solution',
     slug: 'integrate-adiri-testnet-with-bridge-solution',
     inProgress: true,
@@ -188,7 +195,7 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
     },
     {
       text: 'Stress Test Deployed Network for Public Release',
-      status: 'in_progress',
+      done: true,
       slug: 'stress-test-deployed-network',
       details: [
         'Run coordinated stress scenarios across the deployed Adiri environment to validate stability, throughput, and reliability before opening public access.',
@@ -236,7 +243,7 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
     },
     {
       text: 'Control network parameters on-chain',
-      status: 'in_progress',
+      done: true,
       slug: 'control-network-parameters-on-chain',
       details: [
         'Implement on-chain controls for key network parameters to improve transparency, governance, and operational flexibility.',
@@ -288,14 +295,6 @@ export const MILESTONES: Record<PhaseKey, Milestone[]> = {
       slug: 'deploy-new-faucet-service',
       details: [
         'Launch a public faucet that distributes small amounts of testnet TEL, allowing developers and community members to easily access tokens for testing applications and transactions on the network.',
-      ],
-    },
-    {
-      text: 'TN Whitepaper',
-      status: 'in_progress',
-      slug: 'tn-whitepaper',
-      details: [
-        'Drafting and reviewing the Telcoin Network whitepaper to consolidate technical architecture, governance model, and ecosystem positioning for external stakeholders.',
       ],
     },
     {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -15,11 +15,31 @@
   --card: hsla(232, 66%, 17%, 0.88);
   --shadow: 0 32px 60px hsl(225 80% 16% / 0.45);
   --hero-gradient: radial-gradient(
-      circle at 10% 20%,
-      hsl(255 88% 64% / 0.49),
-      transparent 55%
+      ellipse 80% 50% at 10% 15%,
+      hsl(255 88% 64% / 0.45),
+      transparent
     ),
-    linear-gradient(135deg, hsl(248 74% 15%), hsl(214 86% 21%), hsl(194 83% 36%));
+    radial-gradient(
+      ellipse 60% 40% at 90% 35%,
+      hsl(191 94% 50% / 0.18),
+      transparent
+    ),
+    radial-gradient(
+      ellipse 70% 50% at 30% 70%,
+      hsl(220 80% 40% / 0.22),
+      transparent
+    ),
+    radial-gradient(
+      ellipse 50% 60% at 80% 85%,
+      hsl(263 70% 45% / 0.2),
+      transparent
+    ),
+    radial-gradient(
+      ellipse 90% 40% at 50% 50%,
+      hsl(210 70% 20% / 0.3),
+      transparent
+    ),
+    linear-gradient(160deg, hsl(248 74% 12%), hsl(225 70% 14%) 30%, hsl(214 86% 18%) 60%, hsl(200 60% 22%));
   --shimmer: linear-gradient(
     120deg,
     transparent 0%,


### PR DESCRIPTION
## Summary

- Hero announcement card for Adiri Testnet Final Phase launch (pulsing cyan glow, centered layout with Live pill + subtitle text + dev contact)
- May 7 developer notes: stable testnet launch, block explorer live at telscan.io, faucet restored, community test coverage expansion, DNS/infra finalized
- Mark Phase 2 milestones complete: Stress Test Deployed Network, Control network parameters on-chain
- Move TN Whitepaper to Phase 3 (in progress)
- Visual enhancements: gradient title, progress bar shimmer, card hover border glow, section container panels, richer multidirectional background gradient, noise texture overlay, footer glow divider
- All collapsible sections start collapsed by default (Learn More, Milestone Phase 1/2/3)
- Phase 1 and Phase 2 show Complete badge in collapsed state

## Test plan

- [ ] Verify hero card renders with correct copy and pulsing glow animation
- [ ] Verify Phase 1 and Phase 2 show Complete badges
- [ ] Verify TN Whitepaper appears in Phase 3 as in-progress
- [ ] Verify all sections start collapsed
- [ ] Verify section panels provide visual grouping without clutter
- [ ] Verify devs@telcoin.org link is clickable in hero card
- [ ] Check mobile responsiveness

Made with [Cursor](https://cursor.com)