### PR TITLE
Add May 27 developer notes and update status lastUpdated

### DIFF
--- a/src/data/developerNotes.ts
+++ b/src/data/developerNotes.ts
@@ -59,6 +59,18 @@ const APRIL_20_DEVELOPER_NOTES = [
   'Testnet will run in parallel with mainnet indefinitely as a sandbox environment using identical code, tools, and data centers (only differing by chain IDs). This allows safe testing of updates before applying them to mainnet and gives developers a testing environment.',
 ];
 
+
+const MAY_27_DEVELOPER_NOTES = [
+  'Network is feature complete and the core foundation remains stable, with final optimizations now being implemented ahead of mainnet launch.',
+  'Adiri testnet access has expanded with broader RPC endpoint availability, improving public access to network data.',
+  'Validator onboarding is actively underway, with successful onboarding already completed and additional coordination meetings scheduled to bring more validators online.',
+  'Release process has been hardened with cryptographic signatures on official Telcoin Association releases, enabling node operators to verify binaries are maintainer-signed.',
+  'Security focus is concentrated on the network and execution layers, with daily deep scans and attack-surface analysis continuing.',
+  'Smart contract layer is confirmed ready, with final internal code review in progress before third-party audit handoff.',
+  'Discussions are in progress with Cantina to schedule the next audit round, and continuous audits will remain part of ongoing mainnet security operations.',
+  'Bridge partner coordination continues with active testing and deployment on stable Adiri testnet in preparation for full mainnet launch deployment.',
+];
+
 const MAY_07_DEVELOPER_NOTES = [
   'Adiri testnet has officially launched as a stable network — the final phase before mainnet. MNOs can now onboard as validators and developers can build dApps directly on the network.',
   'Block explorer is live at telscan.io, powered by a new Nethereum-based deployment with full transaction routing support.',
@@ -105,6 +117,7 @@ const FEBRUARY_19_DEVELOPER_NOTES = [
 ];
 
 const developerNoteDates = [
+  '2026-05-27T00:00:00Z',
   '2026-05-07T00:00:00Z',
   '2026-04-24T00:00:00Z',
   '2026-04-20T00:00:00Z',
@@ -124,6 +137,11 @@ export const getLatestDeveloperNotesDate = () =>
   );
 
 export const buildDeveloperNoteSections = (recentNotes: string[]): DeveloperNoteSection[] => [
+  {
+    title: 'Developer Notes - Updated 27 May 2026',
+    date: '2026-05-27',
+    items: MAY_27_DEVELOPER_NOTES,
+  },
   {
     title: 'Developer Notes - Updated 7 May 2026',
     date: '2026-05-07',

--- a/status.json
+++ b/status.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "lastUpdated": "2026-04-20T00:00:00Z",
+    "lastUpdated": "2026-05-27T00:00:00Z",
     "overallTrajectoryPct": 93
   },
   "phases": [


### PR DESCRIPTION
### Motivation
- Publish the latest Developer Notes for 27 May 2026 so the UI surfaces the most recent project update. 
- Ensure the global `status.json` `meta.lastUpdated` timestamp matches the new developer note so the site reflects the current status.

### Description
- Added a new `MAY_27_DEVELOPER_NOTES` array with the May 27 entries to `src/data/developerNotes.ts`.
- Inserted `2026-05-27T00:00:00Z` into the `developerNoteDates` array and added a corresponding `Developer Notes - Updated 27 May 2026` section in `buildDeveloperNoteSections` so the new entry is shown first in the UI.
- Updated `status.json` `meta.lastUpdated` to `2026-05-27T00:00:00Z` to keep the data source consistent with the new notes.
- Files changed: `src/data/developerNotes.ts` and `status.json`.

### Testing
- Ran `npm run validate:status` and the `status.json` schema validation passed successfully.
- Ran `npm run typecheck` (`tsc --noEmit`) and TypeScript checks completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1706907c48833096f7b862891e1849)